### PR TITLE
update ssb-uri2

### DIFF
--- a/feeds-lookup.js
+++ b/feeds-lookup.js
@@ -82,7 +82,7 @@ exports.init = function (sbot, config) {
   }
 
   function detectFeedFormat(feedId) {
-    if (feedId.startsWith('@')) {
+    if (feedId.startsWith('@') || SSBURI.isClassicFeedSSBURI(feedId)) {
       return 'classic'
     } else if (SSBURI.isBendyButtV1FeedSSBURI(feedId)) {
       return 'bendybutt-v1'

--- a/keys.js
+++ b/keys.js
@@ -5,7 +5,6 @@
 const crypto = require('crypto')
 const ssbKeys = require('ssb-keys')
 const hkdf = require('futoin-hkdf')
-const SSBURI = require('ssb-uri2')
 
 /**
  * Operations related to keys
@@ -44,25 +43,16 @@ const keys = {
    * @param {string} label
    * @param {'bendybutt-v1' | 'gabbygrove-v1' | 'classic'} format default is 'classic'
    */
-  deriveFeedKeyFromSeed(seed, label, format) {
+  deriveFeedKeyFromSeed(seed, label, format = 'classic') {
     if (!label) throw new Error('label was not supplied')
 
     const ED25519_LENGTH = 32
-
     const derived_seed = hkdf(seed, ED25519_LENGTH, {
       salt: 'ssb',
       info: 'ssb-meta-feed-seed-v1:' + label,
       hash: 'SHA-256',
     })
-    const keys = ssbKeys.generate('ed25519', derived_seed)
-    if (format === 'bendybutt-v1' || format === 'gabbygrove-v1') {
-      const classicUri = SSBURI.fromFeedSigil(keys.id)
-      const { type, /* format, */ data } = SSBURI.decompose(classicUri)
-      const bendyButtUri = SSBURI.compose({ type, format, data })
-      keys.id = bendyButtUri
-    }
-
-    return keys
+    return ssbKeys.generate('ed25519', derived_seed, format)
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "bencode": "^2.0.2",
-    "bipf": "^1.5.1",
+    "bipf": "^1.9.0",
     "debug": "^4.3.0",
     "futoin-hkdf": "^1.4.2",
     "is-canonical-base64": "^1.1.1",
@@ -23,12 +23,12 @@
     "pull-cat": "^1.1.11",
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.14",
-    "ssb-bendy-butt": "~0.12.3",
-    "ssb-bfe": "^3.1.1",
+    "ssb-bendy-butt": "~0.12.5",
+    "ssb-bfe": "^3.3.0",
     "ssb-db2": ">=3.0.0 <=4",
-    "ssb-keys": "^8.2.0",
+    "ssb-keys": "^8.4.0",
     "ssb-ref": "^2.16.0",
-    "ssb-uri2": "^1.5.2"
+    "ssb-uri2": "^2.0.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",
@@ -36,14 +36,14 @@
     "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.2",
     "secret-stack": "^6.4.0",
+    "ssb-db2": "^4.2.0",
     "ssb-db2-box2": "^0.4.0",
     "ssb-caps": "^1.1.0",
-    "tap-bail": "^1.0.0",
-    "tap-spec": "^5.0.0",
+    "tap-arc": "^0.3.5",
     "tape": "^5.3.0"
   },
   "scripts": {
-    "test": "tape test/*.js | tap-bail | tap-spec",
+    "test": "tape test/*.js | tap-arc --bail",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\""
   },

--- a/validate.js
+++ b/validate.js
@@ -132,7 +132,7 @@ function validateSignature(subfeedKey, content, contentSignature, hmacKey) {
   // if the subfeedKey is a supported uri, convert it to sigil for verification
   if (!ref.isFeed(subfeedKey)) {
     if (
-      !SSBURI.isFeedSSBURI(subfeedKey) &&
+      !SSBURI.isClassicFeedSSBURI(subfeedKey) &&
       !SSBURI.isBendyButtV1FeedSSBURI(subfeedKey) &&
       !SSBURI.isGabbyGroveV1FeedSSBURI(subfeedKey)
     ) {


### PR DESCRIPTION
Update to `ssb-uri2@2.0.0` (breaking change). Fairly simple changes, no breaking change caused in/from ssb-meta-feeds.