### PR TITLE
remove unused APIs ensureLoaded, findByIdSync, loadState

### DIFF
--- a/api.js
+++ b/api.js
@@ -48,18 +48,6 @@ exports.init = function (sbot, config) {
     sbot.metafeeds.lookup.findById(feedId, cb)
   }
 
-  function loadState(cb) {
-    sbot.metafeeds.lookup.loadState(cb)
-  }
-
-  function ensureLoaded(feedId, cb) {
-    sbot.metafeeds.lookup.ensureLoaded(feedId, cb)
-  }
-
-  function findByIdSync(feedId) {
-    return sbot.metafeeds.lookup.findByIdSync(feedId)
-  }
-
   function branchStream(opts) {
     return sbot.metafeeds.lookup.branchStream(opts)
   }
@@ -219,9 +207,6 @@ exports.init = function (sbot, config) {
     findOrCreate,
     findAndTombstone,
     findById,
-    findByIdSync,
-    loadState,
-    ensureLoaded,
     branchStream,
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "p-defer": "^3.0.0",
     "promisify-tuple": "^1.2.0",
     "pull-cat": "^1.1.11",
+    "pull-defer": "^0.2.3",
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.14",
     "ssb-bfe": "^3.6.0",

--- a/test/api.js
+++ b/test/api.js
@@ -169,21 +169,7 @@ test('findById and findByIdSync', (t) => {
       t.equals(details.metafeed, testIndexesMF.keys.id)
       t.equals(details.feedformat, 'indexed-v1')
 
-      t.throws(
-        () => {
-          sbot.metafeeds.findByIdSync(testIndexFeed)
-        },
-        /Please call loadState/,
-        'findByIdSync throws'
-      )
-
-      sbot.metafeeds.loadState((err) => {
-        t.error(err, 'no err')
-        const details2 = sbot.metafeeds.findByIdSync(testIndexFeed)
-        t.deepEquals(details2, details, 'findByIdSync same as findById')
-
-        t.end()
-      })
+      t.end()
     })
   })
 })
@@ -227,8 +213,8 @@ test('restart sbot', (t) => {
         path: dir,
       })
 
-    sbot.metafeeds.ensureLoaded(testIndexFeed, () => {
-      const details = sbot.metafeeds.findByIdSync(testIndexFeed)
+    sbot.metafeeds.findById(testIndexFeed, (err, details) => {
+      t.error(err, 'no err')
       t.equals(details.feedpurpose, 'index')
       t.equals(details.metafeed, testIndexesMF.keys.id)
       t.equals(details.feedformat, 'indexed-v1')


### PR DESCRIPTION
We only used `loadState`, `ensureLoaded`, and `findByIdSync` in ssb-ebt, but after [this refactor](https://github.com/ssbc/ssb-ebt/pull/71/files) (merged and published), we don't need these anymore.

Should make it overall easier to work on this module if it has less code.