### PR TITLE
encrypted metafeed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,13 @@ Arguments:
     - `details.feedformat` *String* (optional)
         - either `'classic'` or `'bendybutt-v1'`
         - default: `'classic'`
-    - `details.metadata` *Object* (optional) - for containing other data
-        - if `details.metadata.recps` is used, the subfeed announcement will be encrypted
+    - `details.encrption` *Object*
+    - `details.recps` *Array* (optional)
+       - A collection of "recipients" (GroupId, FeedId, ...) to encrypt the announcement messages to 
+    - `details.encrptionFormat` *String* (optional)
+       - specifies which encrption format to use (you will need an encrption plugin installed e.g. `ssb-box2` installed)
+       - default: `'box2'`
+
 - `cb` *function* delivers the response, has signature `(err, FeedDetails)`, where FeedDetails is
     ```js
     {
@@ -142,9 +147,9 @@ Arguments:
         private: 'Mxa+LL16ws7HZhetR9FbsIOsAeud+ii+9KDUisXkq08jlMEfoG4K8yRIBYlcrBrYUR3zL99Rp+RDXPX0/JfNsQ==.ed25519',
         id: '@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519'
       },
-      metadata: { // example
+      recps: ['%I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.cloaked'], // a GroupId
+      metadata: {
         notes: 'private testing of chess dev',
-        recps: ['@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519']
       },
     }
     ```

--- a/test/api/advanced/find-or-create.test.js
+++ b/test/api/advanced/find-or-create.test.js
@@ -151,3 +151,34 @@ test('advanced.findOrCreate (protected metadata fields)', (t) => {
     )
   })
 })
+
+test('advanced.findOrCreate (encryption)', (t) => {
+  const sbot = Testbot()
+
+  const ownKey = Buffer.from(
+    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
+  sbot.box2.setOwnDMKey(ownKey)
+
+  testReadAndPersisted(t, sbot, (t, sbot, cb) => {
+    sbot.metafeeds.advanced.findOrCreate((err, mf) => {
+      if (err) return cb(err)
+      sbot.metafeeds.advanced.findOrCreate(
+        mf,
+        (f) => f.feedpurpose === 'private',
+        {
+          feedpurpose: 'private',
+          feedformat: 'classic',
+          // ???
+        },
+        (err, f) => {
+          if (err) return cb(err)
+          t.equal(f.feedpurpose, 'private')
+          t.equal(f.metadata.recps[0], sbot.id)
+          cb(null)
+        }
+      )
+    })
+  })
+})


### PR DESCRIPTION
Cases this has to cover:
1. `recp = sbot.id`
   - this is technically an "own_secret" case, but we will hit bumps because ssb-box2 doesn't know about meta-feeds, and "own" now being many keys
       - on encrption, I _think_ box2 will see this as own-encrypt?
       - on decrypt, box2 will almost certainly NOT try own keys

2. `recps = groupId`
   - this case should be fine... as we try group keys on all our messages

3. `recp = someFeedId`
   - this is the DM case, so the shared key should be derived from shardFeedId (author) + someFeedId
   - this should "just work"


