### PR TITLE
encrypted metafeed API (AGAIN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ Arguments:
     - `details.feedformat` *String* (optional)
         - either `'classic'` or `'bendybutt-v1'`
         - default: `'classic'`
-    - `details.encrption` *Object*
     - `details.recps` *Array* (optional)
        - A collection of "recipients" (GroupId, FeedId, ...) to encrypt the announcement messages to 
-    - `details.encrptionFormat` *String* (optional)
+    - `details.encryptionFormat` *String* (optional)
        - specifies which encrption format to use (you will need an encrption plugin installed e.g. `ssb-box2` installed)
        - default: `'box2'`
+    - `details.metadata` *Object* (optional) - for containing other data
 
 - `cb` *function* delivers the response, has signature `(err, FeedDetails)`, where FeedDetails is
     ```js
@@ -161,6 +161,7 @@ Meaning:
 - `feedformat` - the feed format ("classic" or "bendybutt-v1" are current options)
 - `seed` - the data from which is use to derive the `keys` and `id` of this feed.
 - `keys` - cryptographic keys used for signing messages published by this feed (see [ssb-keys])
+- `recps` - an Array of recipients who the meta-feed announcement was encrpted to
 - `metadata` - object containing additional data
 
 NOTES:

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Arguments:
     - `details.recps` *Array* (optional)
        - A collection of "recipients" (GroupId, FeedId, ...) to encrypt the announcement messages to 
     - `details.encryptionFormat` *String* (optional)
-       - specifies which encrption format to use (you will need an encrption plugin installed e.g. `ssb-box2` installed)
+       - specifies which encryption format to use (you will need an encryption plugin installed e.g. `ssb-box2` installed)
        - default: `'box2'`
     - `details.metadata` *Object* (optional) - for containing other data
 
@@ -161,7 +161,7 @@ Meaning:
 - `feedformat` - the feed format ("classic" or "bendybutt-v1" are current options)
 - `seed` - the data from which is use to derive the `keys` and `id` of this feed.
 - `keys` - cryptographic keys used for signing messages published by this feed (see [ssb-keys])
-- `recps` - an Array of recipients who the meta-feed announcement was encrpted to
+- `recps` - an Array of recipients who the metafeed announcement was encrypted to
 - `metadata` - object containing additional data
 
 NOTES:

--- a/README.md
+++ b/README.md
@@ -126,8 +126,13 @@ Arguments:
     - `details.feedformat` *String* (optional)
         - either `'classic'` or `'bendybutt-v1'`
         - default: `'classic'`
-    - `details.metadata` *Object* (optional) - for containing other data
-        - if `details.metadata.recps` is used, the subfeed announcement will be encrypted
+    - `details.encrption` *Object*
+    - `details.recps` *Array* (optional)
+       - A collection of "recipients" (GroupId, FeedId, ...) to encrypt the announcement messages to 
+    - `details.encrptionFormat` *String* (optional)
+       - specifies which encrption format to use (you will need an encrption plugin installed e.g. `ssb-box2` installed)
+       - default: `'box2'`
+
 - `cb` *function* delivers the response, has signature `(err, FeedDetails)`, where FeedDetails is
     ```js
     {
@@ -142,9 +147,9 @@ Arguments:
         private: 'Mxa+LL16ws7HZhetR9FbsIOsAeud+ii+9KDUisXkq08jlMEfoG4K8yRIBYlcrBrYUR3zL99Rp+RDXPX0/JfNsQ==.ed25519',
         id: '@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519'
       },
-      metadata: { // example
+      recps: ['%I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.cloaked'], // a GroupId
+      metadata: {
         notes: 'private testing of chess dev',
-        recps: ['@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519']
       },
     }
     ```

--- a/lookup.js
+++ b/lookup.js
@@ -97,6 +97,7 @@ exports.init = function (sbot, config) {
       details.tombstoned = true
       details.reason = content.reason
     }
+    details.recps = content.recps
     return details
   }
 

--- a/messages.js
+++ b/messages.js
@@ -20,10 +20,17 @@ const { deriveFeedKeyFromSeed } = require('./keys')
  * Low level API for generating messages
  */
 exports.init = function init(sbot) {
-  function optsForAdd(mfKeys, feedKeys, nonce, feedpurpose, metadata) {
-    const type = nonce ? 'metafeed/add/derived' : 'metafeed/add/existing'
+  function optsForAdd(
+    mfKeys,
+    feedKeys,
+    nonce,
+    feedpurpose,
+    metadata,
+    recps,
+    encryptionFormat
+  ) {
     const content = {
-      type,
+      type: nonce ? 'metafeed/add/derived' : 'metafeed/add/existing',
       feedpurpose,
       subfeed: feedKeys.id,
       metafeed: mfKeys.id,
@@ -33,6 +40,7 @@ exports.init = function init(sbot) {
     }
 
     if (nonce) content.nonce = nonce
+    if (recps) content.recps = recps
 
     if (metadata) Object.assign(content, metadata)
 
@@ -41,7 +49,8 @@ exports.init = function init(sbot) {
       keys: mfKeys,
       contentKeys: feedKeys, // see ssb-bendy-butt/format.js
       content,
-      encryptionFormat: 'box2', // in case metadata.recps is set
+      recps,
+      encryptionFormat: encryptionFormat || 'box2',
     }
   }
 
@@ -60,7 +69,15 @@ exports.init = function init(sbot) {
      * `metadata` is an optional object to be included (object spread) in the
      * message `content`.
      */
-    optsForAddDerived(mfKeys, feedpurpose, seed, feedFormat, metadata) {
+    optsForAddDerived(
+      mfKeys,
+      feedpurpose,
+      seed,
+      feedFormat,
+      metadata,
+      recps,
+      encryptionFormat
+    ) {
       if (!supportedFormats.includes(feedFormat)) {
         throw new Error('Unknown feed format: ' + feedFormat)
       }
@@ -71,7 +88,15 @@ exports.init = function init(sbot) {
         feedFormat
       )
 
-      return optsForAdd(mfKeys, feedKeys, nonce, feedpurpose, metadata)
+      return optsForAdd(
+        mfKeys,
+        feedKeys,
+        nonce,
+        feedpurpose,
+        metadata,
+        recps,
+        encryptionFormat
+      )
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "pull-defer": "^0.2.3",
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.14",
-    "ssb-bfe": "^3.6.0",
-    "ssb-db2": ">=3.0.0 <=6",
+    "ssb-bfe": "ssbc/ssb-bfe#cloaked",
     "ssb-keys": "^8.5.0",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.1.0"
@@ -37,12 +36,13 @@
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.2",
+    "run-waterfall": "^1.1.7",
     "secret-stack": "^6.4.0",
     "ssb-bendy-butt": "^1.0.1",
     "ssb-caps": "^1.1.0",
-    "ssb-db2": "^6.1.1",
+    "ssb-db2": "^6.2.1",
     "tap-arc": "^0.3.5",
-    "tape": "^5.6.0"
+    "tape": "^5.6.1"
   },
   "scripts": {
     "test": "npm run test:js && npm run test:only",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.14",
     "ssb-bfe": "^3.6.1",
+    "ssb-db2": ">=3.0.0 <=6",
     "ssb-keys": "^8.5.0",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.2",
-    "run-waterfall": "^1.1.7",
     "secret-stack": "^6.4.0",
     "ssb-bendy-butt": "^1.0.1",
     "ssb-caps": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pull-defer": "^0.2.3",
     "pull-notify": "^0.1.1",
     "pull-stream": "^3.6.14",
-    "ssb-bfe": "ssbc/ssb-bfe#cloaked",
+    "ssb-bfe": "^3.6.1",
     "ssb-keys": "^8.5.0",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.1.0"

--- a/query.js
+++ b/query.js
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 const validate = require('./validate')
+const { NOT_METADATA } = require('./constants')
 const {
   and,
   author,
@@ -61,16 +62,8 @@ exports.init = function (sbot, config) {
 
     collectMetadata(content) {
       const metadata = {}
-      const ignored = [
-        'feedpurpose',
-        'subfeed',
-        'nonce',
-        'metafeed',
-        'tangles',
-        'type',
-      ]
-      for (const key of Object.keys(content)) {
-        if (ignored.includes(key)) continue
+      for (const key in content) {
+        if (NOT_METADATA.has(key)) continue
         metadata[key] = content[key]
       }
       return metadata
@@ -82,7 +75,7 @@ exports.init = function (sbot, config) {
      */
     hydrateFromMsg(msg, seed) {
       const content = msg.value.content
-      const { type, feedpurpose, subfeed, nonce } = content
+      const { type, feedpurpose, subfeed, nonce, recps } = content
       const metadata = self.collectMetadata(content)
       const feedformat = validate.detectFeedFormat(subfeed)
       const existing = type === 'metafeed/add/existing'
@@ -101,6 +94,7 @@ exports.init = function (sbot, config) {
         keys,
         metadata,
         seed: !existing ? seed : undefined,
+        recps: recps || null,
       }
     },
 
@@ -109,7 +103,8 @@ exports.init = function (sbot, config) {
      * "ssb.db.create".
      */
     hydrateFromCreateOpts(opts, seed) {
-      const { feedpurpose, subfeed, metafeed, nonce, type } = opts.content
+      const { feedpurpose, subfeed, metafeed, nonce, type, recps } =
+        opts.content
       const feedformat = validate.detectFeedFormat(subfeed)
       const existing = type === 'metadata/add/existing'
       const keys = existing
@@ -128,6 +123,7 @@ exports.init = function (sbot, config) {
         keys,
         metadata,
         seed: !existing ? seed : undefined,
+        recps: recps || null,
       }
     },
 

--- a/test/api/advanced/find-by-id.test.js
+++ b/test/api/advanced/find-by-id.test.js
@@ -22,7 +22,8 @@ test('advanced.findById', (t) => {
             'feedformat',
             'feedpurpose',
             'metafeed',
-            'metadata'
+            'metadata',
+            'recps'
           ])
           t.equals(details.feedpurpose, 'index')
           t.equals(details.metafeed, indexesMF.keys.id)

--- a/test/api/advanced/find-or-create.test.js
+++ b/test/api/advanced/find-or-create.test.js
@@ -151,3 +151,34 @@ test('advanced.findOrCreate (protected metadata fields)', (t) => {
     )
   })
 })
+
+test('advanced.findOrCreate (encryption)', (t) => {
+  const sbot = Testbot()
+
+  const ownKey = Buffer.from(
+    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
+  sbot.box2.setOwnDMKey(ownKey)
+
+  testReadAndPersisted(t, sbot, (t, sbot, cb) => {
+    sbot.metafeeds.advanced.findOrCreate((err, mf) => {
+      if (err) return cb(err)
+      sbot.metafeeds.advanced.findOrCreate(
+        mf,
+        (f) => f.feedpurpose === 'private',
+        {
+          feedpurpose: 'private',
+          feedformat: 'classic',
+          // ???
+        },
+        (err, f) => {
+          if (err) return cb(err)
+          t.equal(f.feedpurpose, 'private')
+          t.equal(f.metadata.recps[0], sbot.id)
+          cb(null)
+        }
+      )
+    })
+  })
+})

--- a/test/api/advanced/find-or-create.test.js
+++ b/test/api/advanced/find-or-create.test.js
@@ -218,8 +218,6 @@ test('advanced.findOrCreate (encryption - FeedId)', (t) => {
         encryptionFormat: 'box2'
       },
       (err, f) => {
-        if (err) t.error(err, 'no err')
-
         t.match(err?.message, /metafeed encryption currently only supports groupId/)
         sbot.close(true, t.end)
       }

--- a/test/api/advanced/find-or-create.test.js
+++ b/test/api/advanced/find-or-create.test.js
@@ -183,10 +183,9 @@ test('advanced.findOrCreate (encryption - GroupId)', (t) => {
           sbot.db.query(where(type('metafeed/add/derived')), toCallback((err, msgs) => {
             if (err) return cb(err)
 
-            if (msgs.length !== 1) t.equal(msgs.length, 1, 'only one metafeed/add/derived')
+            t.equal(msgs.length, 1, 'only one metafeed/add/derived')
 
             t.deepEqual(msgs[0].value.content.recps, [groupId], 'metafeed/add/derived has recps')
-            // t.deepEqual(typeof msgs[0].value?.meta?.originalContent, 'string', 'metafeed/add/derived is encrypted')
 
             cb(null)
           }))

--- a/test/api/advanced/find-or-create.test.js
+++ b/test/api/advanced/find-or-create.test.js
@@ -218,7 +218,7 @@ test('advanced.findOrCreate (encryption - FeedId)', (t) => {
         encryptionFormat: 'box2'
       },
       (err, f) => {
-        t.match(err?.message, /metafeed encryption currently only supports groupId/)
+        t.match(err.message, /metafeed encryption currently only supports groupId/)
         sbot.close(true, t.end)
       }
     )

--- a/test/testtools.js
+++ b/test/testtools.js
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Unlicense
 
 const { promisify: p } = require('util')
+const waterfall = require('run-waterfall')
 const Testbot = require('./testbot.js')
 
 function testReadAndPersisted(t, sbot, testRead) {
@@ -60,4 +61,5 @@ async function setupTree(sbot) {
 module.exports = {
   testReadAndPersisted,
   setupTree,
+  waterfall,
 }

--- a/test/testtools.js
+++ b/test/testtools.js
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Unlicense
 
 const { promisify: p } = require('util')
-const waterfall = require('run-waterfall')
 const Testbot = require('./testbot.js')
 
 function testReadAndPersisted(t, sbot, testRead) {
@@ -61,5 +60,4 @@ async function setupTree(sbot) {
 module.exports = {
   testReadAndPersisted,
   setupTree,
-  waterfall,
 }


### PR DESCRIPTION
Cases this has to cover:
1. :x: `recp = sbot.id`
   - this is technically an "own_secret" case, but we will hit bumps because ssb-box2 doesn't know about meta-feeds, and "own" now being many keys
       - on encrption, I _think_ box2 will see this as own-encrypt?
       - on decrypt, box2 will almost certainly NOT try own keys

2. :heavy_check_mark:  `recps = groupId`
   - this case should be fine... as we try group keys on all our messages

3. :x: `recp = someFeedId`
   - this is the DM case, so the shared key should be derived from shardFeedId (author) + someFeedId
   - this should "just work"

4. :x: `recp = POBoxId`


:x: = this PR doesn't handle, and has test cases showing they explicitly callback with an error


