### PR TITLE
ensure that findOrCreate / findAndTombstone is never concurrent

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "fast-deep-equal": "^3.1.3",
     "futoin-hkdf": "^1.4.2",
     "is-canonical-base64": "^1.1.1",
+    "mutexify": "^1.4.0",
     "p-defer": "^3.0.0",
     "promisify-tuple": "^1.2.0",
     "pull-cat": "^1.1.11",
@@ -47,7 +48,7 @@
   "scripts": {
     "test": "npm run test:js && npm run test:only",
     "test:js": "tape \"test/**/*.test.js\" | tap-arc --bail",
-    "test:only": "if grep -r --exclude-dir=node_modules --exclude-dir=.git --color 'test\\.only' .; then exit 1; fi",
+    "test:only": "if grep -r --exclude-dir=node_modules --exclude-dir=coverage --exclude-dir=.git --color 'test\\.only' .; then exit 1; fi",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\"",
     "coverage": "c8 --reporter=lcov npm run test"


### PR DESCRIPTION
## Context

I'm working on updating ssb-replication-scheduler to use the new API in ssb-meta-feeds, and in the tests there are some cases of index feeds that are created at the same time.

## Problem

If two `findOrCreate` calls happen concurrently ("at the same time"), then both calls may create a "v1" feed under the root, which leads to a situation like

```mermaid
graph TB;
  root --> v1a[v1] & v1b[v1]
```

This can also happen with shard feeds and leaf feeds.

Also, this concurrency problem can happen with `findAndTombstone`: there should be only one `metafeed/tombstone` message for a given subfeed.

## Solution

Use `mutexify` in `findOrCreate` and `findAndTombstone` to enforce that only one call can happen at a time. I was working on a more complex solution before, which would *allow* concurrency if you're creating unrelated feeds like `root/v1/7/chess` and `root/v1/7/tictactoe`, but I realized that subfeed creation doesn't have to be efficient (we're not going to be creating feeds at a high throughput), so I went with the nuclear (and simpler) solution of allowing only one `findOrCreate` at a time, no matter what the arguments are.

1st :x: 2nd :heavy_check_mark: 