### PR TITLE
main located at root/v1/:shard/main branch

### DIFF
--- a/api.js
+++ b/api.js
@@ -132,7 +132,7 @@ exports.init = function (sbot, config) {
     findOrCreate(root, v1Visit, v1Details, cb)
   }
 
-  function findShard(v1Feed, root, details, cb) {
+  function findShard(root, v1Feed, details, cb) {
     const shardDetails = {
       feedpurpose: pickShard(root.keys.id, details.feedpurpose),
       feedformat: BB1,
@@ -141,7 +141,7 @@ exports.init = function (sbot, config) {
     find(v1Feed, shardVisit, cb)
   }
 
-  function findOrCreateShard(v1Feed, root, details, cb) {
+  function findOrCreateShard(root, v1Feed, details, cb) {
     const shardDetails = {
       feedpurpose: pickShard(root.keys.id, details.feedpurpose),
       feedformat: BB1,
@@ -225,7 +225,7 @@ exports.init = function (sbot, config) {
       const [err3, v1Feed] = await run(findOrCreateV1)(mf)
       if (err3) return release(cb, err3)
       const d = { feedpurpose: 'main' }
-      const [err4, shardFeed] = await run(findOrCreateShard)(v1Feed, mf, d)
+      const [err4, shardFeed] = await run(findOrCreateShard)(mf, v1Feed, d)
       if (err4) return release(cb, err4)
       const visit = (f) => f.feedpurpose === 'main'
       const [err5, added] = await run(find)(shardFeed, visit)
@@ -273,7 +273,7 @@ exports.init = function (sbot, config) {
       findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
 
-        findOrCreateShard(v1Feed, rootFeed, details, (err, shardFeed) => {
+        findOrCreateShard(rootFeed, v1Feed, details, (err, shardFeed) => {
           if (err) return cb(err)
 
           findOrCreate(shardFeed, detailsToVisit(details), details, cb)
@@ -291,7 +291,7 @@ exports.init = function (sbot, config) {
       findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
 
-        findShard(v1Feed, rootFeed, details, (err, shardFeed) => {
+        findShard(rootFeed, v1Feed, details, (err, shardFeed) => {
           if (err) return cb(err)
           if (!shardFeed) return cb(null, false)
 

--- a/api.js
+++ b/api.js
@@ -128,6 +128,28 @@ exports.init = function (sbot, config) {
     }
   }
 
+  function findOrCreateV1(root, cb) {
+    findOrCreate(root, v1Visit, v1Details, cb)
+  }
+
+  function findShard(v1Feed, root, details, cb) {
+    const shardDetails = {
+      feedpurpose: pickShard(root.keys.id, details.feedpurpose),
+      feedformat: BB1,
+    }
+    const shardVisit = detailsToVisit(shardDetails)
+    find(v1Feed, shardVisit, cb)
+  }
+
+  function findOrCreateShard(v1Feed, root, details, cb) {
+    const shardDetails = {
+      feedpurpose: pickShard(root.keys.id, details.feedpurpose),
+      feedformat: BB1,
+    }
+    const shardVisit = detailsToVisit(shardDetails)
+    findOrCreate(v1Feed, shardVisit, shardDetails, cb)
+  }
+
   const findAndTombstoneLock = mutexify()
 
   function findAndTombstone(metafeed, visit, reason, cb) {
@@ -199,16 +221,22 @@ exports.init = function (sbot, config) {
         debug('announce post exists on main feed')
       }
 
-      // Ensure the main feed was "added" on the root meta feed
-      const [err3, added] = await run(find)(mf, (f) => f.feedpurpose === 'main')
+      // Ensure the main feed was "added" on the path root/v1/:shard/main
+      const [err3, v1Feed] = await run(findOrCreateV1)(mf)
       if (err3) return release(cb, err3)
+      const d = { feedpurpose: 'main' }
+      const [err4, shardFeed] = await run(findOrCreateShard)(v1Feed, mf, d)
+      if (err4) return release(cb, err4)
+      const visit = (f) => f.feedpurpose === 'main'
+      const [err5, added] = await run(find)(shardFeed, visit)
+      if (err5) return release(cb, err5)
       if (!added) {
-        debug('adding main feed to root meta feed')
-        const opts = optsForAddExisting(mf.keys, 'main', config.keys)
+        debug('adding main feed to a shard metafeed')
+        const opts = optsForAddExisting(shardFeed.keys, 'main', config.keys)
         const [err5] = await run(sbot.db.create)(opts)
         if (err5) return release(cb, err5)
       } else {
-        debug('main feed already added to root meta feed')
+        debug('main feed already added to a shard metafeed')
       }
 
       cachedRootMetafeed = mf
@@ -242,16 +270,10 @@ exports.init = function (sbot, config) {
     getOrCreateRootMetafeed((err, rootFeed) => {
       if (err) return cb(err)
 
-      findOrCreate(rootFeed, v1Visit, v1Details, (err, v1Feed) => {
+      findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
 
-        const shardDetails = {
-          feedpurpose: pickShard(rootFeed.keys.id, details.feedpurpose),
-          feedformat: BB1,
-        }
-        const shardVisit = detailsToVisit(shardDetails)
-
-        findOrCreate(v1Feed, shardVisit, shardDetails, (err, shardFeed) => {
+        findOrCreateShard(v1Feed, rootFeed, details, (err, shardFeed) => {
           if (err) return cb(err)
 
           findOrCreate(shardFeed, detailsToVisit(details), details, cb)
@@ -266,14 +288,10 @@ exports.init = function (sbot, config) {
     getOrCreateRootMetafeed((err, rootFeed) => {
       if (err) return cb(err)
 
-      find(rootFeed, v1Visit, (err, v1Feed) => {
+      findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
 
-        const shardDetails = {
-          feedpurpose: pickShard(rootFeed.keys.id, details.feedpurpose),
-          feedformat: BB1,
-        }
-        find(v1Feed, detailsToVisit(shardDetails), (err, shardFeed) => {
+        findShard(v1Feed, rootFeed, details, (err, shardFeed) => {
           if (err) return cb(err)
           if (!shardFeed) return cb(null, false)
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test": "npm run test:js && npm run test:only",
     "test:js": "tape \"test/**/*.test.js\" | tap-arc --bail",
     "test:only": "if grep -r --exclude-dir=node_modules --exclude-dir=coverage --exclude-dir=.git --color 'test\\.only' .; then exit 1; fi",
-    "format-code": "prettier --write \"*.js\" \"test/*.js\"",
+    "format-code": "prettier --write \"*.js\" \"test/**/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\"",
     "coverage": "c8 --reporter=lcov npm run test"
   },

--- a/test/api/advanced/find-and-tombstone.test.js
+++ b/test/api/advanced/find-and-tombstone.test.js
@@ -48,7 +48,13 @@ test('advanced.findAndTombstone and tombstoning branchStream', (t) => {
                 }),
                 pull.collect((err, branches) => {
                   if (err) return cb(err)
-                  t.equal(branches.length, 4, 'tombstoned: false')
+                  t.equal(branches.length, 6, 'tombstoned: false')
+                  // root
+                  // root/v1
+                  // root/v1/:shard
+                  // root/v1/:shard/main
+                  // root/indexes
+                  // root/indexes/index
 
                   pull(
                     sbot.metafeeds.branchStream({
@@ -58,8 +64,16 @@ test('advanced.findAndTombstone and tombstoning branchStream', (t) => {
                     }),
                     pull.collect((err, branches) => {
                       if (err) return cb(err)
-                      t.equal(branches.length, 5, 'tombstoned: null')
-                      cb(null)
+                      t.equal(branches.length, 7, 'tombstoned: null')
+                      // root
+                      // root/v1
+                      // root/v1/:shard
+                      // root/v1/:shard/main
+                      // root/chess
+                      // root/indexes
+                      // root/indexes/index
+
+                      cb()
                     })
                   )
                 })

--- a/test/api/advanced/find-by-id.test.js
+++ b/test/api/advanced/find-by-id.test.js
@@ -23,7 +23,7 @@ test('advanced.findById', (t) => {
             'feedpurpose',
             'metafeed',
             'metadata',
-            'recps'
+            'recps',
           ])
           t.equals(details.feedpurpose, 'index')
           t.equals(details.metafeed, indexesMF.keys.id)

--- a/test/api/advanced/find-or-create.test.js
+++ b/test/api/advanced/find-or-create.test.js
@@ -142,10 +142,14 @@ test('advanced.findOrCreate (protected metadata fields)', (t) => {
         feedformat: 'classic',
         metadata: {
           recps: [sbot.id], // naughty! (this is a protected field)
-        }
+        },
       },
       (err, f) => {
-        t.match(err.message, /metadata.recps not allowed/, 'not allowed to use metadata.recps')
+        t.match(
+          err.message,
+          /metadata.recps not allowed/,
+          'not allowed to use metadata.recps'
+        )
         sbot.close(true, t.end)
       }
     )
@@ -173,21 +177,32 @@ test('advanced.findOrCreate (encryption - GroupId)', (t) => {
           feedpurpose: 'private',
           feedformat: 'classic',
           recps: [groupId],
-          encryptionFormat: 'box2'
+          encryptionFormat: 'box2',
         },
         (err, f) => {
           if (err) t.error(err, 'no error')
 
           t.deepEqual(f.recps, [groupId], 'FeedDetails contains recps')
 
-          sbot.db.query(where(type('metafeed/add/derived')), toCallback((err, msgs) => {
-            if (err) return cb(err)
+          sbot.db.query(
+            where(type('metafeed/add/derived')),
+            toCallback((err, anyMsgs) => {
+              if (err) return cb(err)
 
-            t.equal(msgs.length, 1, 'only one metafeed/add/derived')
-            t.deepEqual(msgs[0].value.content.recps, [groupId], 'metafeed/add/derived has recps')
+              const msgs = anyMsgs.filter(
+                (msg) => msg.value.content.feedpurpose === 'private'
+              )
 
-            cb(null)
-          }))
+              t.equal(msgs.length, 1, 'only one metafeed/add/derived')
+              t.deepEqual(
+                msgs[0].value.content.recps,
+                [groupId],
+                'metafeed/add/derived has recps'
+              )
+
+              cb(null)
+            })
+          )
         }
       )
     })
@@ -213,10 +228,13 @@ test('advanced.findOrCreate (encryption - FeedId)', (t) => {
         feedpurpose: 'private',
         feedformat: 'classic',
         recps: [sbot.id],
-        encryptionFormat: 'box2'
+        encryptionFormat: 'box2',
       },
       (err, f) => {
-        t.match(err.message, /metafeed encryption currently only supports groupId/)
+        t.match(
+          err.message,
+          /metafeed encryption currently only supports groupId/
+        )
         sbot.close(true, t.end)
       }
     )

--- a/test/api/branch-stream.test.js
+++ b/test/api/branch-stream.test.js
@@ -22,6 +22,7 @@ test('branchStream', (t) => {
           rootV1,
           rootV1Shard,
           rootV1ShardMain,
+          // These are not under shards because they used the advanced API:
           rootChess,
           rootIndexes,
           rootIndexesIndex,

--- a/test/api/find-or-create.test.js
+++ b/test/api/find-or-create.test.js
@@ -121,7 +121,12 @@ test('double findOrCreate should not create two v1 feeds', async (t) => {
   const shardAnnouncements = msgs.filter((msg) =>
     hexes.includes(msg.value.content.feedpurpose)
   )
-  t.equals(shardAnnouncements.length, 2, 'two shard announcements')
+  // sometimes :shardA and :shardB are the same, among
+  // root/v1/:shardA/main and root/v1/:shardB/chess
+  t.true(
+    shardAnnouncements.length === 1 || shardAnnouncements.length === 2,
+    'shard announcement'
+  )
 
   const chessAnnouncements = msgs.filter(
     (msg) => msg.value.content.feedpurpose === 'chess'

--- a/test/api/find-or-create.test.js
+++ b/test/api/find-or-create.test.js
@@ -19,6 +19,33 @@ test('findOrCreate with no details gives us the root', (t) => {
   })
 })
 
+test('metafeed tree from findOrCreate has root/v1/:shard/main', (t) => {
+  const ssb = Testbot()
+  ssb.metafeeds.findOrCreate((err, feed) => {
+    pull(
+      ssb.metafeeds.branchStream({
+        root: feed.subfeed,
+        old: true,
+        live: false,
+      }),
+      pull.filter((branch) =>
+        branch.find(([id, details]) => details.feedpurpose === 'main')
+      ),
+      pull.collect((err, branches) => {
+        t.error(err, 'no error')
+        t.equal(branches.length, 1, 'only one branch for the main feed')
+        const branch = branches[0]
+        t.equal(branch.length, 4, 'branch has 4 nodes')
+        t.equal(branch[0][1].feedpurpose, 'root', 'root is 1st')
+        t.equal(branch[1][1].feedpurpose, 'v1', 'v1 is 2nd')
+        t.equal(branch[2][1].feedpurpose.length, 1, 'shard is 3rd')
+        t.equal(branch[3][1].feedpurpose, 'main', 'main is 4th')
+        ssb.close(true, t.end)
+      })
+    )
+  })
+})
+
 test('findOrCreate', (t) => {
   const sbot = Testbot()
 
@@ -40,13 +67,26 @@ test('findOrCreate', (t) => {
         pull.collect((err, branches) => {
           if (err) throw err
 
-          t.equal(branches.length, 5, 'correct number of feeds created')
-          // root, v1, shard, chess (AND MAIN)
+          t.true(
+            branches.length === 5 || branches.length === 6,
+            'correct number of feeds created'
+          )
+          // root
+          // root/v1
+          // root/v1/:shardA
+          // root/v1/:shardA/main
+          // root/v1/:shardB
+          // root/v1/:shardB/chess
+          // ... sometimes :shardA === :shardB !
 
           const purposePath = branches
             .pop()
             .map((f) => f[1] && f[1].feedpurpose)
-          t.deepEqual(purposePath, ['root', 'v1', purposePath[2], 'chess'])
+          t.deepEqual(
+            purposePath,
+            ['root', 'v1', purposePath[2], 'chess'],
+            'root/v1/:shard/chess branch exists'
+          )
           // TODO it would be nice for testing that we could deterministically know the shard
           // but I don't know how to fix the "seed" that the root feed is derived from
 
@@ -81,7 +121,7 @@ test('double findOrCreate should not create two v1 feeds', async (t) => {
   const shardAnnouncements = msgs.filter((msg) =>
     hexes.includes(msg.value.content.feedpurpose)
   )
-  t.equals(shardAnnouncements.length, 1, 'only one shard announcement')
+  t.equals(shardAnnouncements.length, 2, 'two shard announcements')
 
   const chessAnnouncements = msgs.filter(
     (msg) => msg.value.content.feedpurpose === 'chess'


### PR DESCRIPTION
## Context

I'm working on ssb-replication-scheduler to make it understand the v1 tree structure, and it expects all feeds to be in paths `root/v1/:shard/___`.

## Problem

ssb-meta-feeds was still doing `root/main`. See also https://github.com/ssbc/ssb-meta-feeds-spec/issues/35

## Solution

When the root metafeed is created, publish the main as a `metafeed/add/existing` under `root/v1/:shard/main`.

1st :x: 2nd :heavy_check_mark: 