### PR TITLE
tidy the API results

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We create a subfeed for `about` messages under our `root` feed using
 subfeed that matches the criteria.
 
 ```js
-const details = { feedpurpose: 'aboutMe' }
+const details = { purpose: 'aboutMe' }
 sbot.metafeeds.findOrCreate(details, (err, aboutMeFeed) => {
   console.log(aboutMeFeed)
 
@@ -97,7 +97,7 @@ Once you have a *FeedDetails* object, like `aboutMeFeed`, you can publish on
 the new subfeed:
 
 ```js
-const details = { feedpurpose: 'aboutMe' }
+const details = { purpose: 'aboutMe' }
 sbot.metafeeds.findOrCreate(details, (err, aboutMeFeed) => {
   console.log(aboutMeFeed)
 
@@ -121,13 +121,13 @@ one which matches these. This creates feeds following the
 [v1 tree structure](https://github.com/ssbc/ssb-meta-feeds-spec#v1).
 
 Arguments:
-- `details` *Object* where 
-    - `details.feedpurpose` *String* any string to characterize the purpose of this new subfeed
-    - `details.feedformat` *String* (optional)
+- `details` *Object* where
+    - `details.purpose` *String* any string to characterize the purpose of this new subfeed
+    - `details.feedFormat` *String* (optional)
         - either `'classic'` or `'bendybutt-v1'`
         - default: `'classic'`
     - `details.recps` *Array* (optional)
-       - A collection of "recipients" (GroupId, FeedId, ...) to encrypt the announcement messages to 
+       - A collection of "recipients" (GroupId, FeedId, ...) to encrypt the announcement messages to
     - `details.encryptionFormat` *String* (optional)
        - specifies which encryption format to use (you will need an encryption plugin installed e.g. `ssb-box2` installed)
        - default: `'box2'`
@@ -136,10 +136,10 @@ Arguments:
 - `cb` *function* delivers the response, has signature `(err, FeedDetails)`, where FeedDetails is
     ```js
     {
-      metafeed: 'ssb:feed/bendybutt-v1/sxK3OnHxdo7yGZ-28HrgpVq8nRBFaOCEGjRE4nB7CO8=',
-      subfeed: '@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519',
-      feedpurpose: 'chess',
-      feedformat: 'classic',
+      id: '@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519',
+      parent: 'ssb:feed/bendybutt-v1/sxK3OnHxdo7yGZ-28HrgpVq8nRBFaOCEGjRE4nB7CO8=',
+      purpose: 'chess',
+      feedFormat: 'classic',
       seed: <Buffer 13 10 25 ab e3 37 20 57 19 0a 1d e4 64 13 e7 38 d2 23 11 48 7d 13 e6 3b 8f ef 72 92 7f db 96 64>
       keys: {
         curve: 'ed25519',
@@ -155,12 +155,12 @@ Arguments:
     ```
 
 Meaning:
-- `metafeed` - the id of the feed this is underneath
-- `subfeed` - the id of this feed, same as `keys.id`
-- `feedpurpose` - a human readable ideally unique handle for this feed
-- `feedformat` - the feed format ("classic" or "bendybutt-v1" are current options)
-- `seed` - the data from which is use to derive the `keys` and `id` of this feed.
 - `keys` - cryptographic keys used for signing messages published by this feed (see [ssb-keys])
+- `id` - the id of this feed, same as `keys.id`
+- `parent` - the id of the parent metafeed under which this feed was announced
+- `purpose` - a human readable ideally unique handle for this feed
+- `feedFormat` - the feed format ("classic", "bendybutt-v1", "indexed-v1", etc)
+- `seed` - the data from which is use to derive the `keys` and `id` of this feed.
 - `recps` - an Array of recipients who the metafeed announcement was encrypted to
 - `metadata` - object containing additional data
 
@@ -176,7 +176,7 @@ it will just load the root metafeed.
 
 Callsback with your `root` FeedDetails object (see `findOrCreate(details, cb)`)
 
-NOTES: 
+NOTES:
 - `metafeed = null` - the root metafeed is the topmost metafeed
 
 ### `sbot.metafeeds.branchStream(opts)`
@@ -189,40 +189,34 @@ branch looks like this:
 
 ```js
 [
-  [rootMetafeedId, rootDetails],
-  [childMetafeedId, childDetails],
-  [grandchildMetafeedId, grandchildDetails],
+  rootDetails,
+  childDetails,
+  grandchildDetails,
 ]
 ```
 
-Or in general, an `Array<[FeedId, Details]>`. The *Details* object has
-the shape `{ feedpurpose, feedformat, metafeed, metadata }` like in `findById`.
+Or in general, an `Array<Details>`. The *Details* object has
+the shape `{ id, purpose, feedFormat, metafeed, metadata }` like what
+`findOrCreate` returns.
 
 `branchStream` will emit all possible branches, which means sub-branches are
 included. For instance, in the example above, `branchStream` would emit:
 
 ```js
-[
-  [rootMetafeedId, rootDetails]
-]
+[ rootDetails ]
+```
+
+and
+
+```js
+[ rootDetails, childDetails ]
 ```
 
 and
 
 ```js
 [
-  [rootMetafeedId, rootDetails],
-  [childMetafeedId, childDetails],
-]
-```
-
-and
-
-```js
-[
-  [rootMetafeedId, rootDetails],
-  [childMetafeedId, childDetails],
-  [grandchildMetafeedId, grandchildDetails],
+  rootDetails, childDetails, grandchildDetails,
 ]
 ```
 

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -27,18 +27,18 @@ Arguments:
     - *null* - this method will then return an arbitrary subfeed under provided `metafeed`
 - `details` - used to create a new subfeed if a match for an existing one is not found, can be
     - *Object*:
-        - `details.feedpurpose` *String* any string to characterize the purpose of this new subfeed
-        - `details.feedformat` *String* either `'classic'` or `'bendybutt-v1'`
+        - `details.purpose` *String* any string to characterize the purpose of this new subfeed
+        - `details.feedFormat` *String* either `'classic'` or `'bendybutt-v1'`
         - `details.metadata` *Object* (optional) - for containing other data
             - if `details.metadata.recps` is used, the subfeed announcement will be encrypted
     - *null* - only allowed if `metafeed` is null (i.e. the details of the `root` FeedDetails)
 - `cb` *function* delivers the response, has signature `(err, FeedDetails)`, where FeedDetails is
     ```js
     {
-      metafeed: 'ssb:feed/bendybutt-v1/sxK3OnHxdo7yGZ-28HrgpVq8nRBFaOCEGjRE4nB7CO8=',
-      subfeed: '@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519',
-      feedpurpose: 'chess',
-      feedformat: 'classic',
+      id: '@I5TBH6BuCvMkSAWJXKwa2FEd8y/fUafkQ1z19PyXzbE=.ed25519',
+      parent: 'ssb:feed/bendybutt-v1/sxK3OnHxdo7yGZ-28HrgpVq8nRBFaOCEGjRE4nB7CO8=',
+      purpose: 'chess',
+      feedFormat: 'classic',
       seed: <Buffer 13 10 25 ab e3 37 20 57 19 0a 1d e4 64 13 e7 38 d2 23 11 48 7d 13 e6 3b 8f ef 72 92 7f db 96 64>
       keys: {
         curve: 'ed25519',
@@ -60,10 +60,10 @@ fetches the *Details* object describing that feed, which is of form:
 
 ```js
 {
-  metafeed,
-  feedpurpose,
-  feedformat,
   id,
+  parent,
+  purpose,
+  feedFormat,
   // seed
   // keys
   metadata

--- a/constants.js
+++ b/constants.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 const BB1 = 'bendybutt-v1'
-const v1Details = { feedpurpose: 'v1', feedformat: BB1 }
+const v1Details = { purpose: 'v1', feedFormat: BB1 }
 const NOT_METADATA = new Set([
   'type',
   'metafeed',

--- a/lookup.js
+++ b/lookup.js
@@ -111,9 +111,7 @@ exports.init = function (sbot, config) {
   }
 
   function updateLookup(msg) {
-    const { type, subfeed, metafeed } = msg.value.content
-    const id = subfeed
-    const parent = metafeed
+    const { type, subfeed: id, metafeed: parent } = msg.value.content
 
     // Update roots
     if (!detailsLookup.has(parent)) {

--- a/test/api/advanced/find-and-tombstone.test.js
+++ b/test/api/advanced/find-and-tombstone.test.js
@@ -19,9 +19,9 @@ test('advanced.findAndTombstone and tombstoning branchStream', (t) => {
       }),
       pull.drain((branch) => {
         t.equals(branch.length, 2, 'live')
-        t.equals(branch[0][0], rootMF.keys.id, 'live')
-        t.equals(branch[1][1].feedpurpose, 'chess', 'live')
-        t.equals(branch[1][1].reason, 'This game is too good', 'live')
+        t.equals(branch[0].id, rootMF.keys.id, 'live')
+        t.equals(branch[1].purpose, 'chess', 'live')
+        t.equals(branch[1].reason, 'This game is too good', 'live')
 
         function testRead(t, sbot, cb) {
           pull(
@@ -32,10 +32,10 @@ test('advanced.findAndTombstone and tombstoning branchStream', (t) => {
             }),
             pull.drain((branch) => {
               t.equals(branch.length, 2)
-              t.equals(branch[0][0], rootMF.keys.id, 'tombstoned: true')
-              t.equals(branch[1][1].feedpurpose, 'chess', 'tombstoned: true')
+              t.equals(branch[0].id, rootMF.keys.id, 'tombstoned: true')
+              t.equals(branch[1].purpose, 'chess', 'tombstoned: true')
               t.equals(
-                branch[1][1].reason,
+                branch[1].reason,
                 'This game is too good',
                 'tombstoned: true'
               )
@@ -88,7 +88,7 @@ test('advanced.findAndTombstone and tombstoning branchStream', (t) => {
 
     sbot.metafeeds.advanced.findAndTombstone(
       rootMF,
-      (f) => f.feedpurpose === 'chess',
+      (f) => f.purpose === 'chess',
       'This game is too good',
       (err) => {
         t.error(err, 'no err')

--- a/test/api/advanced/find-by-id.test.js
+++ b/test/api/advanced/find-by-id.test.js
@@ -19,15 +19,16 @@ test('advanced.findById', (t) => {
           if (err) return cb(err)
 
           t.deepEquals(Object.keys(details), [
-            'feedformat',
-            'feedpurpose',
-            'metafeed',
-            'metadata',
+            'id',
+            'parent',
+            'purpose',
+            'feedFormat',
             'recps',
+            'metadata',
           ])
-          t.equals(details.feedpurpose, 'index')
-          t.equals(details.metafeed, indexesMF.keys.id)
-          t.equals(details.feedformat, 'indexed-v1')
+          t.equals(details.purpose, 'index')
+          t.equals(details.parent, indexesMF.keys.id)
+          t.equals(details.feedFormat, 'indexed-v1')
 
           cb(null)
         })

--- a/test/api/advanced/find-or-create.test.js
+++ b/test/api/advanced/find-or-create.test.js
@@ -17,8 +17,6 @@ test('advanced.findOrCreate(null, null, null, cb)', (t) => {
 
       sbot.metafeeds.advanced.findOrCreate(null, null, null, (err, mf) => {
         t.error(err, 'no err for findOrCreate()')
-        // t.equals(mf.feeds.length, 1, '1 sub feed in the root metafeed')
-        // t.equals(mf.feeds[0].feedpurpose, 'main', 'it is the main feed')
         t.equals(mf.seed.toString('hex').length, 64, 'seed length is okay')
         t.equals(typeof mf.keys.id, 'string', 'key seems okay')
         sbot.close(true, t.end)
@@ -32,8 +30,6 @@ test('advanced.findOrCreate(cb)', (t) => {
 
   sbot.metafeeds.advanced.findOrCreate((err, mf) => {
     t.error(err, 'no err for findOrCreate()')
-    // t.equals(mf.feeds.length, 1, '1 sub feed in the root metafeed')
-    // t.equals(mf.feeds[0].feedpurpose, 'main', 'it is the main feed')
     t.equals(mf.seed.toString('hex').length, 64, 'seed length is okay')
     t.equals(typeof mf.keys.id, 'string', 'key seems okay')
     sbot.close(true, t.end)
@@ -72,14 +68,14 @@ test('advanced.findOrCreate() a sub feed', (t) => {
       // lets create a new chess feed
       sbot.metafeeds.advanced.findOrCreate(
         mf,
-        (f) => f.feedpurpose === 'chess',
+        (f) => f.purpose === 'chess',
         {
-          feedpurpose: 'chess',
-          feedformat: 'classic',
+          purpose: 'chess',
+          feedFormat: 'classic',
           metadata: { score: 0 },
         },
         (err, feed) => {
-          t.equals(feed.feedpurpose, 'chess', 'it is the chess feed')
+          t.equals(feed.purpose, 'chess', 'it is the chess feed')
           t.equals(feed.metadata.score, 0, 'it has metadata')
           sbot.close(true, t.end)
         }
@@ -93,30 +89,30 @@ test('advanced.findOrCreate() a subfeed under a sub meta feed', (t) => {
   sbot.metafeeds.advanced.findOrCreate(null, null, null, (err, rootMF) => {
     sbot.metafeeds.advanced.findOrCreate(
       rootMF,
-      (f) => f.feedpurpose === 'indexes',
-      { feedpurpose: 'indexes', feedformat: 'bendybutt-v1' },
+      (f) => f.purpose === 'indexes',
+      { purpose: 'indexes', feedFormat: 'bendybutt-v1' },
       (err, indexesMF) => {
         t.error(err, 'no err')
-        t.equals(indexesMF.feedpurpose, 'indexes', 'got the indexes meta feed')
+        t.equals(indexesMF.purpose, 'indexes', 'got the indexes meta feed')
         t.true(
-          indexesMF.subfeed.startsWith('ssb:feed/bendybutt-v1/'),
+          indexesMF.id.startsWith('ssb:feed/bendybutt-v1/'),
           'has a bendy butt SSB URI'
         )
 
         sbot.metafeeds.advanced.findOrCreate(
           indexesMF,
-          (f) => f.feedpurpose === 'index',
+          (f) => f.purpose === 'index',
           {
-            feedpurpose: 'index',
-            feedformat: 'indexed-v1',
+            purpose: 'index',
+            feedFormat: 'indexed-v1',
             metadata: { query: 'foo' },
           },
           (err, f) => {
             t.error(err, 'no err')
-            t.equals(f.feedpurpose, 'index', 'it is the index subfeed')
+            t.equals(f.purpose, 'index', 'it is the index subfeed')
             t.equals(f.metadata.query, 'foo', 'query is okay')
             t.true(
-              f.subfeed.startsWith('ssb:feed/indexed-v1/'),
+              f.id.startsWith('ssb:feed/indexed-v1/'),
               'feed format is indexed-v1'
             )
 
@@ -136,10 +132,10 @@ test('advanced.findOrCreate (protected metadata fields)', (t) => {
 
     sbot.metafeeds.advanced.findOrCreate(
       mf,
-      (f) => f.feedpurpose === 'private',
+      (f) => f.purpose === 'private',
       {
-        feedpurpose: 'private',
-        feedformat: 'classic',
+        purpose: 'private',
+        feedFormat: 'classic',
         metadata: {
           recps: [sbot.id], // naughty! (this is a protected field)
         },
@@ -172,10 +168,10 @@ test('advanced.findOrCreate (encryption - GroupId)', (t) => {
 
       sbot.metafeeds.advanced.findOrCreate(
         mf,
-        (f) => f.feedpurpose === 'private',
+        (f) => f.purpose === 'private',
         {
-          feedpurpose: 'private',
-          feedformat: 'classic',
+          purpose: 'private',
+          feedFormat: 'classic',
           recps: [groupId],
           encryptionFormat: 'box2',
         },
@@ -223,10 +219,10 @@ test('advanced.findOrCreate (encryption - FeedId)', (t) => {
 
     sbot.metafeeds.advanced.findOrCreate(
       mf,
-      (f) => f.feedpurpose === 'private',
+      (f) => f.purpose === 'private',
       {
-        feedpurpose: 'private',
-        feedformat: 'classic',
+        purpose: 'private',
+        feedFormat: 'classic',
         recps: [sbot.id],
         encryptionFormat: 'box2',
       },

--- a/test/api/advanced/get-root.test.js
+++ b/test/api/advanced/get-root.test.js
@@ -37,10 +37,10 @@ test('advanced.getRoot (all FeedDetails have same format)', (t) => {
 
           sbot.metafeeds.advanced.findOrCreate(
             mf,
-            (f) => f.feedpurpose === 'chess',
+            (f) => f.purpose === 'chess',
             {
-              feedpurpose: 'chess',
-              feedformat: 'classic',
+              purpose: 'chess',
+              feedFormat: 'classic',
               metadata: { score: 0 },
             },
             (err, feed) => {

--- a/test/api/branch-stream.test.js
+++ b/test/api/branch-stream.test.js
@@ -29,50 +29,39 @@ test('branchStream', (t) => {
         ] = branches
 
         t.equal(root.length, 1, 'root alone')
-        t.equal(typeof root[0][0], 'string', 'root alone')
+        t.equal(typeof root[0].id, 'string', 'root alone')
         t.deepEqual(
-          root[0][1],
+          root[0],
           {
-            feedformat: 'bendybutt-v1',
-            feedpurpose: 'root',
-            metafeed: null,
+            id: root[0].id,
+            parent: null,
+            purpose: 'root',
+            feedFormat: 'bendybutt-v1',
             metadata: {},
           },
           'root alone'
         )
 
         t.equal(rootV1.length, 2, 'root/v1')
-        t.equal(rootV1[1][1].feedpurpose, 'v1', 'root/v1 feedpurpose')
+        t.equal(rootV1[1].purpose, 'v1', 'root/v1 purpose')
 
         t.equal(rootV1Shard.length, 3, 'root/v1/:shard')
-        t.equal(rootV1Shard[1][1].feedpurpose, 'v1', 'root/v1/:shard v1')
-        t.equal(
-          rootV1Shard[2][1].feedpurpose.length,
-          1,
-          'root/v1/:shard feedpurpose'
-        )
+        t.equal(rootV1Shard[1].purpose, 'v1', 'root/v1/:shard v1')
+        t.equal(rootV1Shard[2].purpose.length, 1, 'root/v1/:shard purpose')
 
         t.equal(rootV1ShardMain.length, 4, 'root/v1/:shard/main')
-        t.equal(rootV1ShardMain[1][1].feedpurpose, 'v1', 'root/v1/:shard v1')
-        t.equal(
-          rootV1ShardMain[2][1].feedpurpose.length,
-          1,
-          'root/v1/:shard shard'
-        )
-        t.equal(
-          rootV1ShardMain[3][1].feedpurpose,
-          'main',
-          'root/v1/:shard feedpurpose'
-        )
+        t.equal(rootV1ShardMain[1].purpose, 'v1', 'root/v1/:shard v1')
+        t.equal(rootV1ShardMain[2].purpose.length, 1, 'root/v1/:shard shard')
+        t.equal(rootV1ShardMain[3].purpose, 'main', 'root/v1/:shard purpose')
 
         t.equal(rootChess.length, 2, 'chess branch')
-        t.equal(rootChess[1][1].feedpurpose, 'chess', 'chess branch')
+        t.equal(rootChess[1].purpose, 'chess', 'chess branch')
 
         t.equal(rootIndexes.length, 2, 'indexes branch')
-        t.equal(rootIndexes[1][1].feedpurpose, 'indexes', 'indexes branch')
+        t.equal(rootIndexes[1].purpose, 'indexes', 'indexes branch')
 
         t.equal(rootIndexesIndex.length, 3, 'index branch')
-        t.equal(rootIndexesIndex[2][1].feedpurpose, 'index', 'indexes branch')
+        t.equal(rootIndexesIndex[2].purpose, 'index', 'indexes branch')
 
         cb(null)
       })
@@ -95,7 +84,7 @@ test('branchStream (encrypted announces)', (t) => {
   sbot.box2.addGroupKey(groupId, groupKey)
 
   const details = {
-    feedpurpose: 'dental',
+    purpose: 'dental',
     recps: [groupId],
   }
 
@@ -110,17 +99,11 @@ test('branchStream (encrypted announces)', (t) => {
   pull(
     sbot.metafeeds.branchStream({ old: false, live: true }),
     pull.drain((branch) => {
-      const dentalFeed = branch.find(
-        (feed) => feed[1].feedpurpose === details.feedpurpose
-      )
+      const dentalFeed = branch.find((feed) => feed.purpose === 'dental')
       if (!dentalFeed) return
 
-      t.equal(
-        dentalFeed[1].feedpurpose,
-        'dental',
-        'finds encrypted feed (live)'
-      )
-      t.deepEqual(dentalFeed[1].recps, [groupId], 'has recps details (live)')
+      t.equal(dentalFeed.purpose, 'dental', 'finds encrypted feed (live)')
+      t.deepEqual(dentalFeed.recps, [groupId], 'has recps details (live)')
 
       done()
     })
@@ -142,14 +125,10 @@ test('branchStream (encrypted announces)', (t) => {
           // root/v1/:shardA/main
           // root/v1/:shardB
           // root/v1/:shardB/dental
-          const dentalPath = branches.pop()
-          const [_, dentalFeed] = dentalPath[dentalPath.length - 1]
+          const dentalBranch = branches.pop()
+          const dentalFeed = dentalBranch[dentalBranch.length - 1]
 
-          t.equal(
-            dentalFeed.feedpurpose,
-            details.feedpurpose,
-            'finds encrypted feed'
-          )
+          t.equal(dentalFeed.purpose, 'dental', 'finds encrypted feed')
           t.deepEqual(dentalFeed.recps, details.recps, 'has recps details')
 
           done()

--- a/test/api/find-and-tombstone.test.js
+++ b/test/api/find-and-tombstone.test.js
@@ -12,7 +12,7 @@ test('findAndTombstone', (t) => {
   const sbot = Testbot()
 
   const details = {
-    feedpurpose: 'chess',
+    purpose: 'chess',
   }
 
   sbot.metafeeds.findOrCreate(details, (err, chessF) => {
@@ -29,7 +29,7 @@ test('findAndTombstone', (t) => {
           tombstoned: false,
         }),
         pull.map((branch) =>
-          branch.map((el) => (el[1] ? el[1].feedpurpose : null))
+          branch.map((el) => (el[1] ? el[1].purpose : null))
         ),
         pull.collect((err, branches) => {
           t.error(err, 'no error')
@@ -49,7 +49,7 @@ test('findAndTombstone', (t) => {
 test('double findAndTombstone should not create two messages', async (t) => {
   const ssb = Testbot()
 
-  const details = { feedpurpose: 'chess' }
+  const details = { purpose: 'chess' }
 
   const chessF = await p(ssb.metafeeds.findOrCreate)(details)
   t.ok(chessF, 'chess feed created')

--- a/test/api/find-or-create.test.js
+++ b/test/api/find-or-create.test.js
@@ -12,34 +12,34 @@ test('findOrCreate with no details gives us the root', (t) => {
   const ssb = Testbot()
   ssb.metafeeds.findOrCreate((err, feed) => {
     t.error(err)
-    t.equal(feed.feedpurpose, 'root', 'feedpurpose is correct')
-    t.equal(feed.metafeed, null, 'metafeed is empty')
-    t.equal(feed.feedformat, 'bendybutt-v1', 'feedformat is correct')
+    t.equal(feed.purpose, 'root', 'feedpurpose is correct')
+    t.equal(feed.parent, null, 'metafeed is empty')
+    t.equal(feed.feedFormat, 'bendybutt-v1', 'feedformat is correct')
     ssb.close(true, t.end)
   })
 })
 
 test('metafeed tree from findOrCreate has root/v1/:shard/main', (t) => {
   const ssb = Testbot()
-  ssb.metafeeds.findOrCreate((err, feed) => {
+  ssb.metafeeds.findOrCreate((err, rootMF) => {
     pull(
       ssb.metafeeds.branchStream({
-        root: feed.subfeed,
+        root: rootMF.id,
         old: true,
         live: false,
       }),
       pull.filter((branch) =>
-        branch.find(([id, details]) => details.feedpurpose === 'main')
+        branch.find((feed) => feed.purpose === 'main')
       ),
       pull.collect((err, branches) => {
         t.error(err, 'no error')
         t.equal(branches.length, 1, 'only one branch for the main feed')
         const branch = branches[0]
         t.equal(branch.length, 4, 'branch has 4 nodes')
-        t.equal(branch[0][1].feedpurpose, 'root', 'root is 1st')
-        t.equal(branch[1][1].feedpurpose, 'v1', 'v1 is 2nd')
-        t.equal(branch[2][1].feedpurpose.length, 1, 'shard is 3rd')
-        t.equal(branch[3][1].feedpurpose, 'main', 'main is 4th')
+        t.equal(branch[0].purpose, 'root', 'root is 1st')
+        t.equal(branch[1].purpose, 'v1', 'v1 is 2nd')
+        t.equal(branch[2].purpose.length, 1, 'shard is 3rd')
+        t.equal(branch[3].purpose, 'main', 'main is 4th')
         ssb.close(true, t.end)
       })
     )
@@ -50,13 +50,13 @@ test('findOrCreate', (t) => {
   const sbot = Testbot()
 
   const details = {
-    feedpurpose: 'chess',
-    // feedformat: 'classic', optional
+    purpose: 'chess',
+    // feedFormat: 'classic', optional
   }
 
   sbot.metafeeds.findOrCreate(details, (err, chessF) => {
     if (err) throw err
-    t.equal(chessF.feedpurpose, details.feedpurpose, 'creates feed')
+    t.equal(chessF.purpose, details.purpose, 'creates feed')
 
     sbot.metafeeds.findOrCreate(details, (err, chessF2) => {
       if (err) throw err
@@ -81,7 +81,7 @@ test('findOrCreate', (t) => {
 
           const purposePath = branches
             .pop()
-            .map((f) => f[1] && f[1].feedpurpose)
+            .map((f) => f.purpose)
           t.deepEqual(
             purposePath,
             ['root', 'v1', purposePath[2], 'chess'],
@@ -101,8 +101,8 @@ test('double findOrCreate should not create two v1 feeds', async (t) => {
   const ssb = Testbot()
 
   const [chessF1, chessF2] = await Promise.all([
-    p(ssb.metafeeds.findOrCreate)({ feedpurpose: 'chess' }),
-    p(ssb.metafeeds.findOrCreate)({ feedpurpose: 'chess' }),
+    p(ssb.metafeeds.findOrCreate)({ purpose: 'chess' }),
+    p(ssb.metafeeds.findOrCreate)({ purpose: 'chess' }),
   ])
   t.ok(chessF1, 'chess feed created')
   t.ok(chessF2, 'second chess feed created')

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -68,18 +68,18 @@ test('metafeed with multiple feeds', (t) => {
       indexMsg = m
       sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
         t.equal(hydrated.feeds.length, 2, 'multiple feeds')
-        t.equal(hydrated.feeds[0].feedpurpose, 'main')
+        t.equal(hydrated.feeds[0].purpose, 'main')
         t.equal(hydrated.feeds[0].seed, undefined, 'no seed')
         t.equal(
-          hydrated.feeds[0].subfeed,
+          hydrated.feeds[0].id,
           hydrated.feeds[0].keys.id,
           'correct main keys'
         )
         t.equal(typeof hydrated.feeds[0].keys.id, 'string', 'has key')
-        t.equal(hydrated.feeds[1].feedpurpose, 'index')
+        t.equal(hydrated.feeds[1].purpose, 'index')
         t.true(Buffer.isBuffer(hydrated.feeds[1].seed), 'has seed')
         t.equal(
-          hydrated.feeds[1].subfeed,
+          hydrated.feeds[1].id,
           hydrated.feeds[1].keys.id,
           'correct index keys'
         )
@@ -96,9 +96,9 @@ test('metafeed with tombstones', (t) => {
     db.create(opts, (err) => {
       sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
         t.equal(hydrated.feeds.length, 1, 'single feed')
-        t.equal(hydrated.feeds[0].feedpurpose, 'main')
+        t.equal(hydrated.feeds[0].purpose, 'main')
         t.equal(hydrated.tombstoned.length, 1, '1 tombstone')
-        t.equal(hydrated.tombstoned[0].subfeed, indexKey.id, 'tombstone id')
+        t.equal(hydrated.tombstoned[0].id, indexKey.id, 'tombstone id')
         t.end()
       })
     })

--- a/test/testtools.js
+++ b/test/testtools.js
@@ -32,24 +32,24 @@ async function setupTree(sbot) {
   const rootMF = await p(sbot.metafeeds.advanced.findOrCreate)()
   const chessF = await p(sbot.metafeeds.advanced.findOrCreate)(
     rootMF,
-    (f) => f.feedpurpose === 'chess',
+    (f) => f.purpose === 'chess',
     {
-      feedpurpose: 'chess',
-      feedformat: 'classic',
+      purpose: 'chess',
+      feedFormat: 'classic',
       metadata: { score: 0 },
     }
   )
   const indexesMF = await p(sbot.metafeeds.advanced.findOrCreate)(
     rootMF,
-    (f) => f.feedpurpose === 'indexes',
-    { feedpurpose: 'indexes', feedformat: 'bendybutt-v1' }
+    (f) => f.purpose === 'indexes',
+    { purpose: 'indexes', feedFormat: 'bendybutt-v1' }
   )
   const indexF = await p(sbot.metafeeds.advanced.findOrCreate)(
     indexesMF,
-    (f) => f.feedpurpose === 'index',
+    (f) => f.purpose === 'index',
     {
-      feedpurpose: 'index',
-      feedformat: 'indexed-v1',
+      purpose: 'index',
+      feedFormat: 'indexed-v1',
       metadata: { query: 'foo' },
     }
   )


### PR DESCRIPTION
## Problem

There are a couple legacy decisions in this library that are still haunting us. Like `feedpurpose` instead of `purpose`, it's cemented in the spec and not worth changing it. But also `details.subfeed`. The worst is when `details` refers to the root metafeed, and thus `details.subfeed` is the **id of the root metafeed**. Disgusting! Someone will definitely feel confused by this API.

Also, the branches as tuples `[id, details]` was getting really obnoxious to work with, when it could just be `details.id` etc.

## Solution

We can keep the spec untouched while making this library return more reasonable.

- `details.metafeed` => `details.parent`
- `details.subfeed` => `details.id`
- `details.feedpurpose` => `details.purpose`
- `details.feedformat` => `details.feedFormat` (this one can't be `format` because we also have `details.encryptionFormat`)

:bomb: This is a breaking change.