### PR TITLE
fix findAndTombstone to not use mutation

### DIFF
--- a/api.js
+++ b/api.js
@@ -266,7 +266,7 @@ exports.init = function (sbot, config = {}) {
       return
     }
 
-    if (!details.feedFormat) details.feedFormat = 'classic'
+    const validDetails = { feedFormat: 'classic', ...details }
 
     getOrCreateRootMetafeed((err, rootFeed) => {
       if (err) return cb(err)
@@ -274,17 +274,18 @@ exports.init = function (sbot, config = {}) {
       findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
 
-        findOrCreateShard(rootFeed, v1Feed, details, (err, shardFeed) => {
+        findOrCreateShard(rootFeed, v1Feed, validDetails, (err, shardFeed) => {
           if (err) return cb(err)
 
-          findOrCreate(shardFeed, detailsToVisit(details), details, cb)
+          const visit = detailsToVisit(validDetails)
+          findOrCreate(shardFeed, visit, validDetails, cb)
         })
       })
     })
   }
 
   function commonFindAndTombstone(details, reason, cb) {
-    if (!details.feedformat) details.feedformat = 'classic'
+    const validDetails = { feedFormat: 'classic', ...details }
 
     getOrCreateRootMetafeed((err, rootFeed) => {
       if (err) return cb(err)
@@ -292,11 +293,12 @@ exports.init = function (sbot, config = {}) {
       findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
 
-        findShard(rootFeed, v1Feed, details, (err, shardFeed) => {
+        findShard(rootFeed, v1Feed, validDetails, (err, shardFeed) => {
           if (err) return cb(err)
           if (!shardFeed) return cb(null, false)
 
-          findAndTombstone(shardFeed, detailsToVisit(details), reason, cb)
+          const visit = detailsToVisit(validDetails)
+          findAndTombstone(shardFeed, visit, reason, cb)
         })
       })
     })

--- a/test/api/find-and-tombstone.test.js
+++ b/test/api/find-and-tombstone.test.js
@@ -11,38 +11,38 @@ const Testbot = require('../testbot')
 test('findAndTombstone', (t) => {
   const sbot = Testbot()
 
-  const details = {
-    purpose: 'chess',
-  }
-
-  sbot.metafeeds.findOrCreate(details, (err, chessF) => {
+  sbot.metafeeds.findOrCreate({ purpose: 'chess' }, (err, chessF) => {
     t.error(err, 'no error')
 
-    sbot.metafeeds.findAndTombstone(details, 'stupid game', (err, success) => {
-      t.error(err, 'no error')
-      t.true(success, 'tombstone success')
+    sbot.metafeeds.findAndTombstone(
+      { purpose: 'chess' },
+      'stupid game',
+      (err, success) => {
+        t.error(err, 'no error')
+        t.true(success, 'tombstone success')
 
-      pull(
-        sbot.metafeeds.branchStream({
-          old: true,
-          live: false,
-          tombstoned: false,
-        }),
-        pull.map((branch) =>
-          branch.map((el) => (el[1] ? el[1].purpose : null))
-        ),
-        pull.collect((err, branches) => {
-          t.error(err, 'no error')
+        pull(
+          sbot.metafeeds.branchStream({
+            old: true,
+            live: false,
+            tombstoned: false,
+          }),
+          pull.map((branch) =>
+            branch.map((el) => (el[1] ? el[1].purpose : null))
+          ),
+          pull.collect((err, branches) => {
+            t.error(err, 'no error')
 
-          t.true(
-            branches.every((branch) => !branch.includes('chess')),
-            'gone from branchStream'
-          )
+            t.true(
+              branches.every((branch) => !branch.includes('chess')),
+              'gone from branchStream'
+            )
 
-          sbot.close(true, t.end)
-        })
-      )
-    })
+            sbot.close(true, t.end)
+          })
+        )
+      }
+    )
   })
 })
 


### PR DESCRIPTION
## Context

My tests in ssb-replication-scheduler were failing on findAndTombstone

## Problem

There are two problems:

1. `feedformat` is supposed to be `feedFormat`
2. findAndTombstone mutates the input `details` to add `.feedformat` to it, so if you pass the same `details` object (like our tests do), it'll work, but if you pass two different objects that are deep equal, it won't work

## Solution

Rename `feedformat` to `feedFormat` and don't mutate the inputs.

1st :x: 2nd :heavy_check_mark: 