### PR TITLE
add getTree and printTree APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,59 @@ Arguments:
 The callback is called with `true` on the 2nd argument if tombstoning suceeded,
 or called with an error object on the 1st argument if it failed.
 
+### `sbot.metafeeds.getTree(root, cb)`
+
+Get an object that represents the full metafeed tree under a given root
+metafeed.
+
+Arguments:
+- `root` *String* - feed ID for the root metafeed
+
+The tree object has the shape
+
+```js
+{
+  id,
+  purpose,
+  feedFormat,
+  metadata,
+  children: [
+    {
+      id,
+      purpose,
+      feedFormat,
+      metadata,
+      children
+    },
+  ]
+}
+```
+
+The callback is called with the tree object on the 2nd argument if suceeded,
+or called with an error object on the 1st argument if it failed.
+
+### `sbot.metafeeds.printTree(root, opts, cb)`
+
+Prints (directly to console!) a diagram representation in ASCII for the full
+metafeed tree under a given root metafeed. Example:
+
+```
+root
+└─┬ v1
+  ├─┬ 2
+  │ └── main
+  └─┬ f
+    └── chess
+```
+
+Arguments:
+- `root` *String* - feed ID for the root metafeed
+- `opts` *Object* - object with additional customizations, such as `{id: false}`
+ or `{id: true}`, where `id: true` will print the feed ID for each feed. Default
+ is `id: false`
+
+The callback is called with `undefined` on the 1st argument if printing
+suceeded, or called with an error object if it failed. There is no 2nd argument.
 
 ### Advanced API
 

--- a/api.js
+++ b/api.js
@@ -4,7 +4,6 @@
 
 const run = require('promisify-tuple')
 const deepEqual = require('fast-deep-equal')
-const { isCloakedMsgId } = require('ssb-ref')
 const mutexify = require('mutexify')
 const debug = require('debug')('ssb:meta-feeds')
 const pickShard = require('./pick-shard')
@@ -69,6 +68,14 @@ exports.init = function (sbot, config = {}) {
 
   function branchStream(opts) {
     return sbot.metafeeds.lookup.branchStream(opts)
+  }
+
+  function getTree(root, cb) {
+    return sbot.metafeeds.lookup.getTree(root, cb)
+  }
+
+  function printTree(root, opts, cb) {
+    return sbot.metafeeds.lookup.printTree(root, opts, cb)
   }
 
   function create(metafeed, details, maybeCB) {
@@ -301,6 +308,8 @@ exports.init = function (sbot, config = {}) {
 
   return {
     branchStream,
+    getTree,
+    printTree,
     findOrCreate: commonFindOrCreate,
     findAndTombstone: commonFindAndTombstone,
 

--- a/lookup.js
+++ b/lookup.js
@@ -8,8 +8,6 @@ const cat = require('pull-cat')
 const Notify = require('pull-notify')
 const Defer = require('pull-defer')
 const DeferredPromise = require('p-defer')
-const Ref = require('ssb-ref')
-const SSBURI = require('ssb-uri2')
 const printTreeLibrary = require('print-tree')
 const {
   where,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "is-canonical-base64": "^1.1.1",
     "mutexify": "^1.4.0",
     "p-defer": "^3.0.0",
+    "print-tree": "^0.1.5",
     "promisify-tuple": "^1.2.0",
     "pull-cat": "^1.1.11",
     "pull-defer": "^0.2.3",
@@ -30,7 +31,7 @@
     "ssb-db2": ">=3.0.0 <=6",
     "ssb-keys": "^8.5.0",
     "ssb-ref": "^2.16.0",
-    "ssb-uri2": "^2.1.0"
+    "ssb-uri2": "^2.4.1"
   },
   "devDependencies": {
     "c8": "^7.11.0",

--- a/test/api/tree.test.js
+++ b/test/api/tree.test.js
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+//
+// SPDX-License-Identifier: CC0-1.0
+
+const test = require('tape')
+const Testbot = require('../testbot')
+const { setupTree } = require('../testtools')
+
+test('getTree', (t) => {
+  const ssb = Testbot()
+
+  setupTree(ssb).then(() => {
+    ssb.metafeeds.findOrCreate((err, root) => {
+      t.error(err, 'no error')
+      ssb.metafeeds.getTree(root.id, (err, tree) => {
+        t.error(err, 'no error')
+        t.equals(tree.purpose, 'root')
+        t.equals(tree.children[0].purpose, 'v1')
+        t.equals(tree.children[0].children[0].purpose, '2')
+        t.equals(tree.children[0].children[0].children[0].purpose, 'main')
+        t.equals(tree.children[1].purpose, 'chess')
+        t.equals(tree.children[2].purpose, 'indexes')
+        t.equals(tree.children[2].children[0].purpose, 'index')
+        ssb.close(true, t.end)
+      })
+    })
+  })
+})
+
+test('printTree simple', (t) => {
+  const ssb = Testbot()
+
+  setupTree(ssb).then(() => {
+    ssb.metafeeds.findOrCreate((err, root) => {
+      t.error(err, 'no error')
+
+      const originalConsoleLog = console.log
+      const logged = []
+      console.log = (str) => {
+        logged.push(str)
+      }
+      ssb.metafeeds.printTree(root.id, null, (err, x) => {
+        console.log = originalConsoleLog
+
+        t.error(err, 'no error')
+        t.notOk(x, 'no return value')
+        t.equals(logged.length, 7)
+        const actual = logged.join('\n')
+        const expected = `root
+├─┬ v1
+│ └─┬ 2
+│   └── main
+├── chess
+└─┬ indexes
+  └── index`
+        t.equals(actual, expected)
+        ssb.close(true, t.end)
+      })
+    })
+  })
+})
+
+test('printTree with id', (t) => {
+  const ssb = Testbot()
+
+  setupTree(ssb).then(() => {
+    ssb.metafeeds.findOrCreate((err, root) => {
+      t.error(err, 'no error')
+
+      const originalConsoleLog = console.log
+      const logged = []
+      console.log = (str) => {
+        logged.push(str)
+      }
+      ssb.metafeeds.printTree(root.id, { id: true }, (err, x) => {
+        console.log = originalConsoleLog
+
+        t.error(err, 'no error')
+        t.notOk(x, 'no return value')
+        t.equals(logged.length, 7)
+        t.true(logged[0].includes('root'))
+        t.true(logged[0].includes('ssb:feed/bendybutt-v1/'))
+
+        t.true(logged[1].includes('v1'))
+        t.true(logged[1].includes('ssb:feed/bendybutt-v1/'))
+
+        t.true(logged[2].includes('2'))
+        t.true(logged[2].includes('ssb:feed/bendybutt-v1/'))
+
+        t.true(logged[3].includes('main'))
+        t.true(logged[3].includes('@'))
+
+        t.true(logged[4].includes('chess'))
+        t.true(logged[4].includes('@'))
+
+        t.true(logged[5].includes('indexes'))
+        t.true(logged[5].includes('ssb:feed/bendybutt-v1/'))
+
+        t.true(logged[6].includes('index'))
+        t.true(logged[6].includes('ssb:feed/indexed-v1/'))
+
+        ssb.close(true, t.end)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Context

For fun. I also thought that `printTree` could be very useful in the future when debugging.

## Solution

`printTree()` will put this kind of ASCII diagram in the console:

```
root
└─┬ v1
  ├─┬ 2
  │ └── main
  └─┬ f
    └── chess
```

`getTree()` will return an object that has the full hierarchical structure for the tree. This could be a good alternative to `branchStream` for some downstream modules. 

The new dependency [has a tiny footprint](https://bundlephobia.com/package/print-tree@0.1.5).