### PR TITLE
branchStream can be called immediately after findOrCreate

### DIFF
--- a/api.js
+++ b/api.js
@@ -273,7 +273,7 @@ exports.init = function (sbot, config = {}) {
     getOrCreateRootMetafeed((err, rootFeed) => {
       if (err) return cb(err)
 
-      sbot.metafeeds.lookup.updateLookupFromCreatedFeed(rootFeed)
+      sbot.metafeeds.lookup.updateLookupRoot(rootFeed)
       findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
         sbot.metafeeds.lookup.updateLookupFromCreatedFeed(v1Feed)

--- a/api.js
+++ b/api.js
@@ -280,7 +280,11 @@ exports.init = function (sbot, config = {}) {
           if (err) return cb(err)
 
           const visit = detailsToVisit(validDetails)
-          findOrCreate(shardFeed, visit, validDetails, cb)
+          findOrCreate(shardFeed, visit, validDetails, (err, feed) => {
+            if (err) return cb(err)
+            sbot.metafeeds.lookup.updateLookupFromCreatedFeed(feed)
+            cb(null, feed)
+          })
         })
       })
     })

--- a/api.js
+++ b/api.js
@@ -273,16 +273,20 @@ exports.init = function (sbot, config = {}) {
     getOrCreateRootMetafeed((err, rootFeed) => {
       if (err) return cb(err)
 
+      sbot.metafeeds.lookup.updateLookupFromCreatedFeed(rootFeed)
       findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
+        sbot.metafeeds.lookup.updateLookupFromCreatedFeed(v1Feed)
 
         findOrCreateShard(rootFeed, v1Feed, validDetails, (err, shardFeed) => {
           if (err) return cb(err)
+          sbot.metafeeds.lookup.updateLookupFromCreatedFeed(shardFeed)
 
           const visit = detailsToVisit(validDetails)
           findOrCreate(shardFeed, visit, validDetails, (err, feed) => {
             if (err) return cb(err)
             sbot.metafeeds.lookup.updateLookupFromCreatedFeed(feed)
+
             cb(null, feed)
           })
         })

--- a/lookup.js
+++ b/lookup.js
@@ -91,15 +91,15 @@ exports.init = function (sbot, config) {
     }
   }
 
-  function msgToDetails(prevDetails, msg) {
+  function msgToDetails(msg) {
     const content = msg.value.content
-    const details = { ...prevDetails }
-    details.id = prevDetails ? prevDetails.id : content.subfeed
-    details.parent = content.metafeed || details.parent
-    details.purpose = content.feedpurpose || details.purpose
+    const details = {}
+    if (content.subfeed) details.id = content.subfeed
+    if (content.metafeed) details.parent = content.metafeed
+    if (content.feedpurpose) details.purpose = content.feedpurpose
     details.feedFormat = validate.detectFeedFormat(content.subfeed)
     details.recps = content.recps || null
-    details.metadata = {} || details.metafeed
+    details.metadata = {} || details.metadata
     const keys = Object.keys(content).filter((k) => !NOT_METADATA.has(k))
     for (const key of keys) {
       details.metadata[key] = content[key]
@@ -111,8 +111,18 @@ exports.init = function (sbot, config) {
     return details
   }
 
-  function updateLookup(msg) {
-    const { type, subfeed: id, metafeed: parent } = msg.value.content
+  function updateLookupFromMsg(msg) {
+    const details = msgToDetails(msg)
+    const isNew = msg.value.content.type.startsWith('metafeed/add/')
+    updateLookup(details, isNew)
+  }
+
+  function updateLookupFromCreatedFeed(details) {
+    updateLookup(details, true)
+  }
+
+  function updateLookup(details, isNew) {
+    const { id, parent } = details
 
     // Update roots
     if (!detailsLookup.has(parent)) {
@@ -121,7 +131,7 @@ exports.init = function (sbot, config) {
     }
 
     // Update children
-    if (type.startsWith('metafeed/add/')) {
+    if (isNew) {
       if (childrenLookup.has(parent)) {
         const children = childrenLookup.get(parent)
         children.add(id)
@@ -133,8 +143,9 @@ exports.init = function (sbot, config) {
     }
 
     // Update details
-    const details = msgToDetails(detailsLookup.get(id), msg)
-    detailsLookup.set(id, details)
+    const prevDetails = detailsLookup.get(id)
+    const nextDetails = { ...prevDetails, ...details }
+    detailsLookup.set(id, nextDetails)
     roots.delete(id)
     ensureQueue.flush(id)
 
@@ -148,7 +159,7 @@ exports.init = function (sbot, config) {
     pull(
       sbot.db.query(where(authorIsBendyButtV1()), toPullStream()),
       pull.filter((msg) => validate.isValid(msg)),
-      pull.drain(updateLookup, (err) => {
+      pull.drain(updateLookupFromMsg, (err) => {
         if (err) return console.error(err)
 
         stateLoadedP.resolve()
@@ -162,7 +173,7 @@ exports.init = function (sbot, config) {
         pull(
           sbot.db.query(where(authorIsBendyButtV1()), live(), toPullStream()),
           pull.filter((msg) => validate.isValid(msg)),
-          (liveDrainer = pull.drain(updateLookup))
+          (liveDrainer = pull.drain(updateLookupFromMsg))
         )
       })
     )
@@ -253,7 +264,7 @@ exports.init = function (sbot, config) {
           return cb(null, null)
         }
 
-        const details = msgToDetails(undefined, msgs[0])
+        const details = msgToDetails(msgs[0])
         cb(null, details)
       })
     )
@@ -365,5 +376,6 @@ exports.init = function (sbot, config) {
     branchStream,
     getTree,
     printTree,
+    updateLookupFromCreatedFeed,
   }
 }

--- a/lookup.js
+++ b/lookup.js
@@ -8,6 +8,7 @@ const cat = require('pull-cat')
 const Notify = require('pull-notify')
 const Defer = require('pull-defer')
 const DeferredPromise = require('p-defer')
+const deepEqual = require('fast-deep-equal')
 const printTreeLibrary = require('print-tree')
 const {
   where,
@@ -134,7 +135,7 @@ exports.init = function (sbot, config) {
     if (isNew) {
       if (childrenLookup.has(parent)) {
         const children = childrenLookup.get(parent)
-        children.add(id)
+        if (!children.has(id)) children.add(id)
       } else {
         const children = new Set()
         children.add(id)
@@ -144,6 +145,7 @@ exports.init = function (sbot, config) {
 
     // Update details
     const prevDetails = detailsLookup.get(id)
+    if (deepEqual(prevDetails, details)) return
     const nextDetails = { ...prevDetails, ...details }
     detailsLookup.set(id, nextDetails)
     roots.delete(id)

--- a/lookup.js
+++ b/lookup.js
@@ -100,7 +100,7 @@ exports.init = function (sbot, config) {
     if (content.feedpurpose) details.purpose = content.feedpurpose
     details.feedFormat = validate.detectFeedFormat(content.subfeed)
     details.recps = content.recps || null
-    details.metadata = {} || details.metadata
+    details.metadata = {}
     const keys = Object.keys(content).filter((k) => !NOT_METADATA.has(k))
     for (const key of keys) {
       details.metadata[key] = content[key]

--- a/lookup.js
+++ b/lookup.js
@@ -122,6 +122,13 @@ exports.init = function (sbot, config) {
     updateLookup(details, true)
   }
 
+  function updateLookupRoot(details) {
+    const { id } = details
+    if (detailsLookup.has(id)) return
+    detailsLookup.set(id, details)
+    roots.add(id)
+  }
+
   function updateLookup(details, isNew) {
     const { id, parent } = details
 
@@ -379,5 +386,6 @@ exports.init = function (sbot, config) {
     getTree,
     printTree,
     updateLookupFromCreatedFeed,
+    updateLookupRoot,
   }
 }

--- a/test/api/branch-stream.test.js
+++ b/test/api/branch-stream.test.js
@@ -115,32 +115,26 @@ test('branchStream (encrypted announces)', (t) => {
   sbot.metafeeds.findOrCreate(details, (err, f) => {
     if (err) t.error(err, 'no error')
 
-    const query = () =>
-      pull(
-        sbot.metafeeds.branchStream({ old: true, live: false }),
-        pull.collect((err, branches) => {
-          if (err) t.error(err, 'no error')
+    pull(
+      sbot.metafeeds.branchStream({ old: true, live: false }),
+      pull.collect((err, branches) => {
+        if (err) t.error(err, 'no error')
 
-          t.equal(branches.length, 6, '6 feed branches')
-          // root
-          // root/v1
-          // root/v1/:shardA
-          // root/v1/:shardA/main
-          // root/v1/:shardB
-          // root/v1/:shardB/dental
-          const dentalBranch = branches.pop()
-          const dentalFeed = dentalBranch[dentalBranch.length - 1]
+        t.equal(branches.length, 6, '6 feed branches')
+        // root
+        // root/v1
+        // root/v1/:shardA
+        // root/v1/:shardA/main
+        // root/v1/:shardB
+        // root/v1/:shardB/dental
+        const dentalBranch = branches.pop()
+        const dentalFeed = dentalBranch[dentalBranch.length - 1]
 
-          t.equal(dentalFeed.purpose, 'dental', 'finds encrypted feed')
-          t.deepEqual(dentalFeed.recps, details.recps, 'has recps details')
+        t.equal(dentalFeed.purpose, 'dental', 'finds encrypted feed')
+        t.deepEqual(dentalFeed.recps, details.recps, 'has recps details')
 
-          done()
-        })
-      )
-
-    setTimeout(query, 500)
-    // unfortunately if you run the query straight away, it fails
-    // this could be because it takes a moment for indexing of encrypted messages?
-    // you can see the delay by logging in lookup.js #updateLookup
+        done()
+      })
+    )
   })
 })

--- a/test/api/find-or-create.test.js
+++ b/test/api/find-or-create.test.js
@@ -65,26 +65,19 @@ test('findOrCreate', (t) => {
         pull.collect((err, branches) => {
           if (err) throw err
 
-          t.true(
-            branches.length === 5 || branches.length === 6,
-            'correct number of feeds created'
-          )
+          t.equal(branches.length, 6, 'correct number of feeds created')
           // root
           // root/v1
-          // root/v1/:shardA
-          // root/v1/:shardA/main
-          // root/v1/:shardB
-          // root/v1/:shardB/chess
-          // ... sometimes :shardA === :shardB !
+          // root/v1/3
+          // root/v1/3/chess
+          // root/v1/2
+          // root/v1/2/main
 
-          const purposePath = branches.pop().map((f) => f.purpose)
-          t.deepEqual(
-            purposePath,
-            ['root', 'v1', purposePath[2], 'chess'],
-            'root/v1/:shard/chess branch exists'
-          )
-          // TODO it would be nice for testing that we could deterministically know the shard
-          // but I don't know how to fix the "seed" that the root feed is derived from
+          const chessPath = branches[3].map((f) => f.purpose).join('/')
+          t.deepEqual(chessPath, 'root/v1/3/chess', 'chess branch exists')
+
+          const mainPath = branches[5].map((f) => f.purpose).join('/')
+          t.deepEqual(mainPath, 'root/v1/2/main', 'main branch exists')
 
           sbot.close(true, t.end)
         })


### PR DESCRIPTION
## Context

Tests were failing downstream in ssb-tribes2 when I created a groupFeed and then tried to use branchStream to replicate that to other peers.

## Problem

After findOrCreate, branchStream had to "wait" for the ssb-db2 bendybutt message to be processed *and then* converted to a "details" object.

If you called branchStream immediately after findOrCreate was done, this means you would miss the newly-created leaf feed.

## Solution

As soon as findOrCreate is done, `updateLookup` on the branchStream logic so that the data is synchronously available there.

1st :x: 2nd :heavy_check_mark: 