### PR TITLE
add .keys to all feed details you own

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,9 @@ branch looks like this:
 ```
 
 Or in general, an `Array<Details>`. The *Details* object has
-the shape `{ id, purpose, feedFormat, metafeed, metadata }` like what
-`findOrCreate` returns.
+the shape `{ id, purpose, feedFormat, keys, parent, metadata }` like what
+`findOrCreate` returns. If the details is for a feed that doesn't belong to you,
+the `keys` field will not be present.
 
 `branchStream` will emit all possible branches, which means sub-branches are
 included. For instance, in the example above, `branchStream` would emit:

--- a/api.js
+++ b/api.js
@@ -210,6 +210,7 @@ exports.init = function (sbot, config = {}) {
         debug('loaded seed')
         mf = buildRootFeedDetails(loadedSeed)
       }
+      sbot.metafeeds.lookup.updateMyRoot(mf)
 
       // Ensure root meta feed announcement exists on the main feed
       const [err2, announcements] = await run(getAnnounces)()
@@ -273,19 +274,18 @@ exports.init = function (sbot, config = {}) {
     getOrCreateRootMetafeed((err, rootFeed) => {
       if (err) return cb(err)
 
-      sbot.metafeeds.lookup.updateLookupRoot(rootFeed)
       findOrCreateV1(rootFeed, (err, v1Feed) => {
         if (err) return cb(err)
-        sbot.metafeeds.lookup.updateLookupFromCreatedFeed(v1Feed)
+        sbot.metafeeds.lookup.updateFromCreatedFeed(v1Feed)
 
         findOrCreateShard(rootFeed, v1Feed, validDetails, (err, shardFeed) => {
           if (err) return cb(err)
-          sbot.metafeeds.lookup.updateLookupFromCreatedFeed(shardFeed)
+          sbot.metafeeds.lookup.updateFromCreatedFeed(shardFeed)
 
           const visit = detailsToVisit(validDetails)
           findOrCreate(shardFeed, visit, validDetails, (err, feed) => {
             if (err) return cb(err)
-            sbot.metafeeds.lookup.updateLookupFromCreatedFeed(feed)
+            sbot.metafeeds.lookup.updateFromCreatedFeed(feed)
 
             cb(null, feed)
           })

--- a/query.js
+++ b/query.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 const validate = require('./validate')
-const { NOT_METADATA } = require('./constants')
+const { NOT_METADATA, BB1 } = require('./constants')
 const {
   and,
   author,
@@ -74,7 +74,19 @@ exports.init = function (sbot, config) {
      */
     hydrateFromMsg(msg, seed) {
       const content = msg.value.content
-      const { type, feedpurpose, subfeed, nonce, recps } = content
+      const { type, metafeed, feedpurpose, subfeed, nonce, recps } = content
+      if (type === 'metafeed/announce') {
+        return {
+          id: metafeed,
+          parent: null,
+          purpose: 'root',
+          feedFormat: BB1,
+          seed,
+          keys: sbot.metafeeds.keys.deriveRootMetaFeedKeyFromSeed(seed),
+          recps: null,
+          metadata: {},
+        }
+      }
       const metadata = self.collectMetadata(content)
       const feedFormat = validate.detectFeedFormat(subfeed)
       const existing = type === 'metafeed/add/existing'

--- a/test/api/branch-stream.test.js
+++ b/test/api/branch-stream.test.js
@@ -30,41 +30,41 @@ test('branchStream', (t) => {
 
         t.equal(root.length, 1, 'root alone')
         t.equal(typeof root[0].id, 'string', 'root alone')
-        t.deepEqual(
-          root[0],
-          {
-            id: root[0].id,
-            parent: null,
-            purpose: 'root',
-            feedFormat: 'bendybutt-v1',
-            metadata: {},
-          },
-          'root alone'
-        )
+        t.equal(root[0].purpose, 'root', 'root alone')
+        t.equal(root[0].parent, null, 'root alone')
+        t.equal(root[0].feedFormat, 'bendybutt-v1', 'root alone')
+        t.deepEqual(root[0].metadata, {}, 'root alone')
+        t.ok(root[0].keys, 'root has keys')
 
         t.equal(rootV1.length, 2, 'root/v1 length')
         t.equal(rootV1[0].purpose, 'root', 'root/v1 root')
         t.equal(rootV1[1].purpose, 'v1', 'root/v1 v1')
+        t.ok(rootV1[1].keys, 'root/v1 has keys')
 
         t.equal(rootV1Shard.length, 3, 'root/v1/:shard length')
         t.equal(rootV1Shard[0].purpose, 'root', 'root/v1/:shard root')
         t.equal(rootV1Shard[1].purpose, 'v1', 'root/v1/:shard v1')
         t.equal(rootV1Shard[2].purpose, '2', 'root/v1/:shard shard')
+        t.ok(rootV1Shard[2].keys, 'root/v1/:shard has keys')
 
         t.equal(rootV1ShardMain.length, 4, 'root/v1/:shard/main')
         t.equal(rootV1ShardMain[0].purpose, 'root', 'root/v1/:shard/main root')
         t.equal(rootV1ShardMain[1].purpose, 'v1', 'root/v1/:shard/main v1')
         t.equal(rootV1ShardMain[2].purpose, '2', 'root/v1/:shard/main shard')
         t.equal(rootV1ShardMain[3].purpose, 'main', 'root/v1/:shard/main main')
+        t.ok(rootV1ShardMain[3].keys, 'root/v1/:shard/main has keys')
 
         t.equal(rootChess.length, 2, 'chess branch')
         t.equal(rootChess[1].purpose, 'chess', 'chess branch')
+        t.ok(rootChess[1].keys, 'root/chess has keys')
 
         t.equal(rootIndexes.length, 2, 'indexes branch')
         t.equal(rootIndexes[1].purpose, 'indexes', 'indexes branch')
+        t.ok(rootIndexes[1].keys, 'root/indexes has keys')
 
         t.equal(rootIndexesIndex.length, 3, 'index branch')
         t.equal(rootIndexesIndex[2].purpose, 'index', 'indexes branch')
+        t.ok(rootIndexesIndex[2].keys, 'root/indexes/index has keys')
 
         cb(null)
       })


### PR DESCRIPTION
## Context

In ssb-box2 we're going to have to traverse "my" metafeed tree, and then match that with other peers' metafeed tree to create DH keys.

## Problem

When using default branchStream, it returns any branch in the "forest" (the collection of all trees), and there isn't any way how we can know whether a branch belongs to _my_ tree, or some _other_ peer's tree.

## Solution

Add `.keys` field for all feed details returned by branchStream if I own that feed. If `details.keys` exists, it means you own the subfeed (well, by definition, because if you have the `keys`, you can publish to that feed). 

In the implementation, this requires loading our `seed` before querying ssb-db2 for messages that build up the branches lookup data structure. We also load the root metafeed keys in that data structure ASAP, so that whenever we stumble upon a feed, we can check if it's parents `details.keys` exists, and then hydrate the keys with the seed.

Asking for a review from @arj03, but pinging @mixmix just to be aware of this PR.