### PR TITLE
introduce FeedDetails class

### DIFF
--- a/FeedDetails.js
+++ b/FeedDetails.js
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros <contact@staltz.com>
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
+const { NOT_METADATA, BB1 } = require('./constants')
+const validate = require('./validate')
+const metafeedKeys = require('./keys')
+
+const correctPassword = Symbol('FeedDetails')
+
+function collectMetadata(content) {
+  const metadata = {}
+  for (const key in content) {
+    if (NOT_METADATA.has(key)) continue
+    metadata[key] = content[key]
+  }
+  return metadata
+}
+
+class FeedDetails {
+  constructor(
+    password,
+    id,
+    parent,
+    purpose,
+    feedFormat,
+    seed = null,
+    keys = null,
+    recps = null,
+    metadata = {},
+    tombstoned = false,
+    tombstoneReason = null
+  ) {
+    if (password !== correctPassword) {
+      throw new Error('dont use `new FeedDetails()`, use FeedDetails.from*()')
+    }
+    this.id = id
+    this.parent = parent
+    this.purpose = purpose
+    this.feedFormat = feedFormat
+    this.seed = seed
+    this.keys = keys
+    this.recps = recps
+    this.metadata = metadata
+    this.tombstoned = tombstoned
+    this.tombstoneReason = tombstoneReason
+  }
+
+  /**
+   * Builds FeedDetails based on my metafeed message that "added" or "announced"
+   * the feed.
+   */
+  static fromMyMsg(msg, seed, config) {
+    const content = msg.value.content
+    const { type, metafeed, feedpurpose, subfeed, nonce, recps } = content
+    if (type === 'metafeed/announce') {
+      return new FeedDetails(
+        correctPassword,
+        metafeed,
+        null,
+        'root',
+        BB1,
+        seed,
+        metafeedKeys.deriveRootMetaFeedKeyFromSeed(seed)
+      )
+    }
+    const feedFormat = validate.detectFeedFormat(subfeed)
+    const metadata = collectMetadata(content)
+    const existing = type === 'metafeed/add/existing'
+    const isTombstoned = type === 'metafeed/tombstone'
+    const keys = existing
+      ? config.keys
+      : type === 'metafeed/add/derived'
+      ? metafeedKeys.deriveFeedKeyFromSeed(
+          seed,
+          nonce.toString('base64'),
+          feedFormat
+        )
+      : null
+    return new FeedDetails(
+      correctPassword,
+      subfeed,
+      msg.value.author,
+      feedpurpose,
+      feedFormat,
+      existing ? undefined : seed,
+      keys,
+      recps || null,
+      metadata,
+      isTombstoned,
+      isTombstoned ? content.reason : null
+    )
+  }
+
+  /**
+   * Builds FeedDetails based on some other peer's metafeed message that "added"
+   * or "announced" the feed.
+   */
+  static fromOtherMsg(msg) {
+    const content = msg.value.content
+    const { type, subfeed, metafeed, feedpurpose, recps } = content
+    const feedFormat = validate.detectFeedFormat(subfeed)
+    const metadata = collectMetadata(content)
+    const isTombstoned = type === 'metafeed/tombstone'
+    return new FeedDetails(
+      correctPassword,
+      subfeed,
+      metafeed,
+      feedpurpose,
+      feedFormat,
+      undefined,
+      undefined,
+      recps || null,
+      metadata,
+      isTombstoned ? true : undefined,
+      isTombstoned ? content.reason : undefined
+    )
+  }
+
+  /**
+   * Builds FeedDetails based on an "opts" argument that'll be given to
+   * `ssb.db.create`.
+   */
+  static fromCreateOpts(opts, seed, config) {
+    const { feedpurpose, subfeed, metafeed, nonce, type, recps } = opts.content
+    const feedFormat = validate.detectFeedFormat(subfeed)
+    const existing = type === 'metadata/add/existing'
+    const keys = existing
+      ? config.keys
+      : metafeedKeys.deriveFeedKeyFromSeed(
+          seed,
+          nonce.toString('base64'),
+          feedFormat
+        )
+    const metadata = collectMetadata(opts.content)
+    return new FeedDetails(
+      correctPassword,
+      subfeed,
+      metafeed,
+      feedpurpose,
+      feedFormat,
+      existing ? undefined : seed,
+      keys,
+      recps || null,
+      metadata
+    )
+  }
+
+  /**
+   * Builds FeedDetails based on a bendybutt-v1 feed ID, assuming it's a root.
+   */
+  static fromRootId(id) {
+    return new FeedDetails(correctPassword, id, null, 'root', BB1)
+  }
+
+  /**
+   * Builds FeedDetails for my root metafeed, based on the seed buffer.
+   */
+  static fromRootSeed(seed) {
+    const keys = metafeedKeys.deriveRootMetaFeedKeyFromSeed(seed)
+    return new FeedDetails(
+      correctPassword,
+      keys.id,
+      null,
+      'root',
+      BB1,
+      seed,
+      keys
+    )
+  }
+
+  /**
+   * Incorporates the given FeedDetails into this one, updating our properties.
+   */
+  update(feedDetails) {
+    this.purpose = feedDetails.purpose || this.purpose
+    this.metadata = { ...this.metadata, ...feedDetails.metadata }
+    if (typeof feedDetails.tombstoned === 'boolean') {
+      this.tombstoned = feedDetails.tombstoned
+      this.tombstoneReason = feedDetails.tombstoneReason || this.tombstoneReason
+    }
+  }
+
+  /**
+   * Checks whether another FeedDetails instance has all the same properties as
+   * this one.
+   */
+  equals(feedDetails) {
+    return (
+      this.id === feedDetails.id &&
+      this.parent === feedDetails.parent &&
+      this.purpose === feedDetails.purpose &&
+      this.feedFormat === feedDetails.feedFormat &&
+      this.seed === feedDetails.seed &&
+      this.keys === feedDetails.keys &&
+      this.recps === feedDetails.recps &&
+      this.metadata === feedDetails.metadata &&
+      this.tombstoned === feedDetails.tombstoned &&
+      this.tombstoneReason === feedDetails.tombstoneReason
+    )
+  }
+}
+
+module.exports = FeedDetails

--- a/test/api/advanced/find-and-tombstone.test.js
+++ b/test/api/advanced/find-and-tombstone.test.js
@@ -21,7 +21,7 @@ test('advanced.findAndTombstone and tombstoning branchStream', (t) => {
         t.equals(branch.length, 2, 'live')
         t.equals(branch[0].id, rootMF.keys.id, 'live')
         t.equals(branch[1].purpose, 'chess', 'live')
-        t.equals(branch[1].reason, 'This game is too good', 'live')
+        t.equals(branch[1].tombstoneReason, 'This game is too good', 'live')
 
         function testRead(t, sbot, cb) {
           pull(
@@ -35,7 +35,7 @@ test('advanced.findAndTombstone and tombstoning branchStream', (t) => {
               t.equals(branch[0].id, rootMF.keys.id, 'tombstoned: true')
               t.equals(branch[1].purpose, 'chess', 'tombstoned: true')
               t.equals(
-                branch[1].reason,
+                branch[1].tombstoneReason,
                 'This game is too good',
                 'tombstoned: true'
               )

--- a/test/api/advanced/find-by-id.test.js
+++ b/test/api/advanced/find-by-id.test.js
@@ -23,8 +23,12 @@ test('advanced.findById', (t) => {
             'parent',
             'purpose',
             'feedFormat',
+            'seed',
+            'keys',
             'recps',
             'metadata',
+            'tombstoned',
+            'tombstoneReason',
           ])
           t.equals(details.purpose, 'index')
           t.equals(details.parent, indexesMF.keys.id)

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -69,7 +69,7 @@ test('metafeed with multiple feeds', (t) => {
       sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
         t.equal(hydrated.feeds.length, 2, 'multiple feeds')
         t.equal(hydrated.feeds[0].purpose, 'main')
-        t.equal(hydrated.feeds[0].seed, undefined, 'no seed')
+        t.equal(hydrated.feeds[0].seed, null, 'no seed')
         t.equal(
           hydrated.feeds[0].id,
           hydrated.feeds[0].keys.id,


### PR DESCRIPTION
## Context

This is not a necessary addition, it's a nice-to-have addition.

I was thinking how we return `{ id, parent, purpose, ... }` objects in a bunch of places, and it's getting kind of out of hand. Several different files are creating/updating these objects, and they *have* to follow the same shape, but we're not enforcing the same shape.

Moreover, I'm also thinking that there will be many of these objects, because each branch in `branchStream` has many of these. It will be better to profile memory usage if we use classes, because they show up immediately in the Chrome DevTools. Also, it helps the V8 optimizer if all of the objects share exactly the same shape (same set of `Object.keys()` always) because then under the hood it creates a hidden `struct` (in C) to back all these objects.

You could say that's premature optimization, but the primary motivation here is just organization and code readability. It's a bonus that it just happens to be better for performance and memory profiling.

## Solution

Introduce a new class `FeedDetails` that can be constructed using various helpers: `fromMyMsg`, `fromCreateOpts`, etc. Replace all the hand-written feed details objects with this class instance.

There's a tiny breaking change with tombstoned feed details: `reason` => `tombstoneReason`. I can revert that if y'all have a different opinion.

Tests pass locally, but they don't run in CI yet because this PR isn't targeting `master`. This PR should be merged only after #104 is merged.