### PR TITLE
Fix FeedDetails.equals to compare buffers correctly

### DIFF
--- a/FeedDetails.js
+++ b/FeedDetails.js
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
+const deepEqual = require('fast-deep-equal')
 const { NOT_METADATA, BB1 } = require('./constants')
 const validate = require('./validate')
 const metafeedKeys = require('./keys')
@@ -186,15 +187,23 @@ class FeedDetails {
    * this one.
    */
   equals(feedDetails) {
+    const seedIsTheSame =
+      this.seed === feedDetails.seed ||
+      (Buffer.isBuffer(this.seed) &&
+        Buffer.isBuffer(feedDetails.seed) &&
+        this.seed.equals(feedDetails.seed))
+
+    const keysIsTheSame =
+      this.keys === feedDetails.keys || deepEqual(this.keys, feedDetails.keys)
     return (
       this.id === feedDetails.id &&
       this.parent === feedDetails.parent &&
       this.purpose === feedDetails.purpose &&
       this.feedFormat === feedDetails.feedFormat &&
-      this.seed === feedDetails.seed &&
-      this.keys === feedDetails.keys &&
+      seedIsTheSame &&
+      keysIsTheSame &&
       this.recps === feedDetails.recps &&
-      this.metadata === feedDetails.metadata &&
+      deepEqual(this.metadata, feedDetails.metadata) &&
       this.tombstoned === feedDetails.tombstoned &&
       this.tombstoneReason === feedDetails.tombstoneReason
     )

--- a/test/FeedDetails.test.js
+++ b/test/FeedDetails.test.js
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2021 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+const test = require('tape')
+const FeedDetails = require('../FeedDetails')
+
+test('FeedDetails.equals', (t) => {
+  const buf1 = Buffer.alloc(32).fill(0)
+  const fd1 = FeedDetails.fromRootSeed(buf1)
+  const buf2 = Buffer.alloc(32).fill(0)
+  const fd2 = FeedDetails.fromRootSeed(buf2)
+  t.notEquals(buf1, buf2, 'buffers are not equal')
+  t.true(fd1.equals(fd2), 'FeedDetails are equal')
+  t.end()
+})


### PR DESCRIPTION
## Context

I got some weird duplicate branches coming out of `branchStream`, and it turned out that the '.equals()' function wasn't working here:

https://github.com/ssbc/ssb-meta-feeds/blob/895781aa18d789d79600020119bb22150061ef3a/lookup.js#L134

## Problem

`FeedDetails`'s `equals()` is too simplistic, it's comparing two buffers with `===`, and it's comparing two objects (`keys`) with `===` too.

## Solution

Compare buffers with `Buffer.equals` and compare objects with fast-deep-equal.

1st :x: 2nd :heavy_check_mark: 
