### PR TITLE
test that getTree has all details

### DIFF
--- a/test/api/tree.test.js
+++ b/test/api/tree.test.js
@@ -15,6 +15,11 @@ test('getTree', (t) => {
       ssb.metafeeds.getTree(root.id, (err, tree) => {
         t.error(err, 'no error')
         t.equals(tree.purpose, 'root')
+        t.ok(tree.keys, 'root keys')
+        t.ok(tree.seed, 'root seed')
+        t.equals(tree.recps, null, 'root recps')
+        t.equals(tree.tombstoned, false, 'root tombstoned')
+        t.equals(tree.tombstoneReason, null, 'root tombstoneReason')
         t.equals(tree.children[0].purpose, 'v1')
         t.equals(tree.children[0].children[0].purpose, '2')
         t.equals(tree.children[0].children[0].children[0].purpose, 'main')


### PR DESCRIPTION
## Context

Last PR in this repo for today.

I'm working on ssb-box2 and it calls `getTree()` to traverse the forest and match "mirrored feeds".

## Problem

The tree data structure was missing all the details I needed, e.g. `keys`.

## Solution

Add those fields.

1st :x: 2nd :heavy_check_mark: 