### PR TITLE
fix branchStream to restart after box2 decryption

### DIFF
--- a/test/testbot.js
+++ b/test/testbot.js
@@ -10,11 +10,13 @@ const caps = require('ssb-caps')
 
 let count = 0
 
-// opts.path      (optional)
-//   opts.name    (optional) - convenience method for deterministic opts.path
-// opts.keys      (optional)
-// opts.rimraf    (optional) - clear the directory before start (default: true)
-
+/**
+ * - opts.path (optional)
+ *   - opts.name (optional) - convenience method for deterministic opts.path
+ * - opts.rimraf (optional) - clear the directory before start (default: true)
+ * - opts.keys (optional)
+ * - opts.metafeedSeed (optional)
+ */
 module.exports = function createSbot(opts = {}) {
   const dir = opts.path || `/tmp/metafeeds-metafeed-${opts.name || count++}`
   if (opts.rimraf !== false) rimraf.sync(dir)
@@ -32,10 +34,12 @@ module.exports = function createSbot(opts = {}) {
     path: dir,
     keys,
     metafeeds: {
-      seed: Buffer.from(
-        '000000000000000000000000000000000000000000000000000000000000beef',
-        'hex'
-      ),
+      seed:
+        opts.metafeedSeed ||
+        Buffer.from(
+          '000000000000000000000000000000000000000000000000000000000000beef',
+          'hex'
+        ),
     },
   })
 }


### PR DESCRIPTION
## Context

I'm working on putting 2b funky recps in ssb-tribes2, and noticed a race condition in the tests.

## Problem

There's a race condition between:

1. Replicate the shard feed that announces (encrypted!) a group feed
2. Replicate the `group/add-member` message (on the invitations feed) that allows us to decrypt (1)

Ideally, (2) happens first and then (1), but if (1) happens first we have a problem. Even though ssb-tribes2 will run reindexEncrypted() when it bumps into a `group/add-member` msg, the `branchStream()` in ssb-meta-feeds won't know that it has to "restart". It just stays stuck in live mode, and of course there are no "new" messages. We only have old messages that were decrypted.

## Solution

This is not an ideal solution, but it works. I have an idea for the ideal case, which would be a new API in ssb-db2 that streams all the messages that were freshly decrypted. We need that not only for this branchStream problem, but in other cases too, like in the ssb-box2 "monitor" that matches DM triangles.

The current solution is to just track `indexingActive` (because reindexEncrypted() bumps that) and restart the branchStream query when indexingActive goes to zero. The live stream was also converted to old-and-live because that's the only way how we can get the old-but-freshly-decrypted messages, AND still get the live messages.

1st :x: 2nd :heavy_check_mark: 