### PR TITLE
fix branchStream "loadState" logic

### DIFF
--- a/lookup.js
+++ b/lookup.js
@@ -50,6 +50,7 @@ function subfeed(feedId) {
 
 exports.init = function (sbot, config) {
   const stateLoadedP = DeferredPromise()
+  let stateLoaded = false
   let loadStateRequested = false
   let liveDrainer = null
   let notifyNewBranch = null
@@ -164,6 +165,7 @@ exports.init = function (sbot, config) {
           pull.drain(updateLookupFromMsg, (err) => {
             if (err) return console.error(err)
 
+            stateLoaded = true
             stateLoadedP.resolve()
 
             sbot.close.hook(function (fn, args) {
@@ -279,8 +281,8 @@ exports.init = function (sbot, config) {
   }
 
   function branchStream(opts) {
-    if (!loadStateRequested) {
-      loadState()
+    if (!stateLoaded) {
+      if (!loadStateRequested) loadState()
       const deferred = Defer.source()
       stateLoadedP.promise.then(() => {
         deferred.resolve(branchStream(opts))


### PR DESCRIPTION
## Context

https://github.com/ssbc/ssb-meta-feeds/pull/110#discussion_r1023762878

## Problem

If you call branchStream with live first, and then immediately call branchStream with old second, then the second one will just assume that the state has loaded, without actually waiting for it.

## Solution

Just a bit of booleans and some ifs.

1st :x: 2nd :heavy_check_mark: 