### PR TITLE
Add test for branchStream root opt

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "husky": "^4.3.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
+    "pull-many": "^1.0.9",
     "rimraf": "^3.0.2",
     "secret-stack": "^6.4.0",
     "ssb-bendy-butt": "^1.0.1",
@@ -45,6 +46,7 @@
     "ssb-caps": "^1.1.0",
     "ssb-classic": "^1.1.0",
     "ssb-db2": "^6.3.0",
+    "ssb-ebt": "^9.1.2",
     "tap-arc": "^0.3.5",
     "tape": "^5.6.1"
   },

--- a/test/testbot.js
+++ b/test/testbot.js
@@ -28,6 +28,8 @@ module.exports = function createSbot(opts = {}) {
     .use(require('ssb-bendy-butt'))
     .use(require('ssb-classic'))
     .use(require('ssb-box2'))
+    .use(require('ssb-db2/compat/ebt'))
+    .use(require('ssb-ebt'))
     .use(require('../'))
 
   return stack({


### PR DESCRIPTION
fixes https://github.com/ssbc/ssb-meta-feeds/issues/114

* [ ] fix bug where you can't use root on someone else's root id
* [ ] add check that the user is actually inputting a root id and not like an object
* [ ] shouldn't output anything if it's an invalid root id. like here it just seems to make up a root feed https://github.com/ssbc/ssb-tribes2/pull/78#discussion_r1158493143
* [ ] arj wrote that "this [line](https://github.com/ssbc/ssb-meta-feeds/blob/08ef0edeff00fa9bf3a1f9b9b6bd77589647e859/lookup.js#L90) looks wrong. It basically just tests that you have a seed yourself, not that it correspond to anything within the message. "